### PR TITLE
Remove 'Open on' from PDB buttons in protein modal

### DIFF
--- a/main.js
+++ b/main.js
@@ -571,8 +571,8 @@ class MoleculeManager {
                     </div>
                 </div>
                 <div class="pdb-external-links">
-                    <button id="open-rcsb-btn" class="view-structure-btn rcsb-btn">Open on RCSB PDB</button>
-                    <button id="open-pdbe-btn" class="view-structure-btn pdbe-btn">Open on PDBe</button>
+                    <button id="open-rcsb-btn" class="view-structure-btn rcsb-btn">RCSB PDB</button>
+                    <button id="open-pdbe-btn" class="view-structure-btn pdbe-btn">PDBe</button>
                 </div>
             </div>
             <div class="details-section">


### PR DESCRIPTION
## Summary
- shorten external link buttons in protein modal by removing the 'Open on' prefix

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f7aad81608329ab25100feebaf5f3