### PR TITLE
feat: add molecule export modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,10 +45,11 @@
             <button class="tab-button">Proteins</button>
         </div>
         <div class="content">
-            <div class="database-header">
-                <h2>Molecular Database</h2>
-                <div class="header-buttons">
+                <div class="database-header">
+                    <h2>Molecular Database</h2>
+                    <div class="header-buttons">
                     <button id="add-molecule-btn" class="add-btn" title="Add new molecule">+</button>
+                    <button id="save-molecules-btn" class="save-btn" title="Save molecules">💾</button>
                     <button id="delete-all-btn" class="delete-all-btn" title="Delete all molecules">
                         <svg viewBox="0 0 24 24" width="18" height="18">
                             <path fill="currentColor"
@@ -179,6 +180,28 @@
                     <button id="cancel-btn" class="btn-secondary">Cancel</button>
                     <button id="confirm-add-btn" class="btn-primary">Add Molecule</button>
                 </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Save Molecules Modal -->
+    <div id="save-molecules-modal" class="modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3>Save Molecules</h3>
+                <span class="close" id="close-save-modal">&times;</span>
+            </div>
+            <div class="modal-body">
+                <label for="save-file-name">File Name:</label>
+                <input type="text" id="save-file-name" placeholder="molecules" value="molecules">
+                <label for="save-file-format">Format:</label>
+                <select id="save-file-format">
+                    <option value="json">JSON</option>
+                </select>
+            </div>
+            <div class="modal-footer">
+                <button id="cancel-save-btn" class="btn-secondary">Cancel</button>
+                <button id="confirm-save-btn" class="btn-primary">Save</button>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
                     <div class="header-buttons">
                     <button id="add-molecule-btn" class="add-btn" title="Add new molecule">+</button>
                     <button id="save-molecules-btn" class="save-btn" title="Save molecules">💾</button>
+                    <button id="load-molecules-btn" class="load-btn" title="Load molecules">📂</button>
                     <button id="delete-all-btn" class="delete-all-btn" title="Delete all molecules">
                         <svg viewBox="0 0 24 24" width="18" height="18">
                             <path fill="currentColor"
@@ -202,6 +203,24 @@
             <div class="modal-footer">
                 <button id="cancel-save-btn" class="btn-secondary">Cancel</button>
                 <button id="confirm-save-btn" class="btn-primary">Save</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Load Molecules Modal -->
+    <div id="load-molecules-modal" class="modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3>Load Molecules</h3>
+                <span class="close" id="close-load-modal">&times;</span>
+            </div>
+            <div class="modal-body">
+                <label for="load-file-input">Select JSON File:</label>
+                <input type="file" id="load-file-input" accept=".json,application/json">
+            </div>
+            <div class="modal-footer">
+                <button id="cancel-load-btn" class="btn-secondary">Cancel</button>
+                <button id="confirm-load-btn" class="btn-primary">Load</button>
             </div>
         </div>
     </div>

--- a/main.js
+++ b/main.js
@@ -1353,6 +1353,14 @@ function initializeModal() {
     const saveFileNameInput = document.getElementById('save-file-name');
     const saveFileFormat = document.getElementById('save-file-format');
 
+    // Load Molecules Modal elements
+    const loadModal = document.getElementById('load-molecules-modal');
+    const loadBtn = document.getElementById('load-molecules-btn');
+    const closeLoadModalBtn = document.getElementById('close-load-modal');
+    const cancelLoadBtn = document.getElementById('cancel-load-btn');
+    const confirmLoadBtn = document.getElementById('confirm-load-btn');
+    const loadFileInput = document.getElementById('load-file-input');
+
     // Open add modal
     addBtn.addEventListener('click', () => {
         addModal.style.display = 'block';
@@ -1363,6 +1371,13 @@ function initializeModal() {
     saveBtn.addEventListener('click', () => {
         saveModal.style.display = 'block';
         saveFileNameInput.focus();
+    });
+
+    // Open load modal
+    loadBtn.addEventListener('click', () => {
+        loadModal.style.display = 'block';
+        loadFileInput.value = '';
+        loadFileInput.focus();
     });
 
     // Delete all molecules with confirmation
@@ -1396,6 +1411,12 @@ function initializeModal() {
         saveFileNameInput.value = 'molecules';
     };
 
+    // Close load modal function
+    const closeLoadModal = () => {
+        loadModal.style.display = 'none';
+        loadFileInput.value = '';
+    };
+
     // Open add fragment modal
     addFragmentBtn.addEventListener('click', () => {
         addFragmentModal.style.display = 'block';
@@ -1419,6 +1440,8 @@ function initializeModal() {
     cancelFragmentBtn.addEventListener('click', closeFragmentModal);
     closeSaveModalBtn.addEventListener('click', closeSaveModal);
     cancelSaveBtn.addEventListener('click', closeSaveModal);
+    closeLoadModalBtn.addEventListener('click', closeLoadModal);
+    cancelLoadBtn.addEventListener('click', closeLoadModal);
 
     // Handle confirm add fragment
     confirmFragmentBtn.addEventListener('click', () => {
@@ -1444,6 +1467,9 @@ function initializeModal() {
         }
         if (event.target === saveModal) {
             closeSaveModal();
+        }
+        if (event.target === loadModal) {
+            closeLoadModal();
         }
     });
 
@@ -1494,6 +1520,44 @@ function initializeModal() {
     }
 
     confirmBtn.addEventListener('click', addMolecule);
+
+    // Load molecules function
+    confirmLoadBtn.addEventListener('click', () => {
+        const file = loadFileInput.files[0];
+        if (!file) {
+            showNotification('Please select a JSON file', 'info');
+            return;
+        }
+
+        const reader = new FileReader();
+        reader.onload = (e) => {
+            try {
+                const data = JSON.parse(e.target.result);
+                if (Array.isArray(data)) {
+                    // Clear existing molecules without notification
+                    moleculeManager.molecules = [];
+                    document.querySelectorAll('.molecule-card').forEach(card => card.remove());
+                    if (moleculeManager.loadingIndicator) {
+                        moleculeManager.loadingIndicator.style.display = 'none';
+                    }
+
+                    data.forEach(mol => {
+                        if (mol.code) {
+                            moleculeManager.addMolecule(mol.code);
+                        }
+                    });
+                    showNotification('Molecules loaded!', 'success');
+                    closeLoadModal();
+                } else {
+                    showNotification('Invalid file format', 'error');
+                }
+            } catch (err) {
+                console.error(err);
+                showNotification('Failed to load file', 'error');
+            }
+        };
+        reader.readAsText(file);
+    });
 
     // Save molecules function
     confirmSaveBtn.addEventListener('click', () => {

--- a/main.js
+++ b/main.js
@@ -1344,10 +1344,25 @@ function initializeModal() {
     const cancelFragmentBtn = document.getElementById('cancel-add-fragment-btn');
     const confirmFragmentBtn = document.getElementById('confirm-add-fragment-btn');
 
+    // Save Molecules Modal elements
+    const saveModal = document.getElementById('save-molecules-modal');
+    const saveBtn = document.getElementById('save-molecules-btn');
+    const closeSaveModalBtn = document.getElementById('close-save-modal');
+    const cancelSaveBtn = document.getElementById('cancel-save-btn');
+    const confirmSaveBtn = document.getElementById('confirm-save-btn');
+    const saveFileNameInput = document.getElementById('save-file-name');
+    const saveFileFormat = document.getElementById('save-file-format');
+
     // Open add modal
     addBtn.addEventListener('click', () => {
         addModal.style.display = 'block';
         input.focus();
+    });
+
+    // Open save modal
+    saveBtn.addEventListener('click', () => {
+        saveModal.style.display = 'block';
+        saveFileNameInput.focus();
     });
 
     // Delete all molecules with confirmation
@@ -1375,6 +1390,12 @@ function initializeModal() {
         detailsModal.style.display = 'none';
     };
 
+    // Close save modal function
+    const closeSaveModal = () => {
+        saveModal.style.display = 'none';
+        saveFileNameInput.value = 'molecules';
+    };
+
     // Open add fragment modal
     addFragmentBtn.addEventListener('click', () => {
         addFragmentModal.style.display = 'block';
@@ -1396,6 +1417,8 @@ function initializeModal() {
     closeDetailsBtn.addEventListener('click', closeDetailsModal);
     closeFragmentModalBtn.addEventListener('click', closeFragmentModal);
     cancelFragmentBtn.addEventListener('click', closeFragmentModal);
+    closeSaveModalBtn.addEventListener('click', closeSaveModal);
+    cancelSaveBtn.addEventListener('click', closeSaveModal);
 
     // Handle confirm add fragment
     confirmFragmentBtn.addEventListener('click', () => {
@@ -1418,6 +1441,9 @@ function initializeModal() {
         }
         if (event.target === addFragmentModal) {
             closeFragmentModal();
+        }
+        if (event.target === saveModal) {
+            closeSaveModal();
         }
     });
 
@@ -1468,6 +1494,34 @@ function initializeModal() {
     }
 
     confirmBtn.addEventListener('click', addMolecule);
+
+    // Save molecules function
+    confirmSaveBtn.addEventListener('click', () => {
+        const filename = saveFileNameInput.value.trim() || 'molecules';
+        const format = saveFileFormat.value;
+        const molecules = moleculeManager.getAllMolecules();
+        let blob;
+        let ext = '';
+
+        if (format === 'json') {
+            blob = new Blob([JSON.stringify(molecules, null, 2)], { type: 'application/json' });
+            ext = '.json';
+        } else {
+            blob = new Blob([JSON.stringify(molecules, null, 2)]);
+        }
+
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename.endsWith(ext) ? filename : filename + ext;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+
+        closeSaveModal();
+        showNotification('Molecules saved!', 'success');
+    });
 }
 
 function initializeTabs() {

--- a/style.css
+++ b/style.css
@@ -277,6 +277,28 @@ main {
     box-shadow: 0 4px 8px rgba(110, 69, 226, 0.4);
 }
 
+.save-btn {
+    background: #28a745;
+    color: white;
+    border: none;
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    font-size: 20px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.3s ease;
+    box-shadow: 0 2px 4px rgba(40, 167, 69, 0.3);
+}
+
+.save-btn:hover {
+    background: #218838;
+    transform: scale(1.05);
+    box-shadow: 0 4px 8px rgba(40, 167, 69, 0.4);
+}
+
 .header-buttons {
     display: flex;
     gap: 10px;
@@ -353,6 +375,10 @@ main {
 }
 
 .add-btn:active {
+    transform: scale(0.95);
+}
+
+.save-btn:active {
     transform: scale(0.95);
 }
 

--- a/style.css
+++ b/style.css
@@ -299,6 +299,28 @@ main {
     box-shadow: 0 4px 8px rgba(40, 167, 69, 0.4);
 }
 
+.load-btn {
+    background: #17a2b8;
+    color: white;
+    border: none;
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    font-size: 20px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.3s ease;
+    box-shadow: 0 2px 4px rgba(23, 162, 184, 0.3);
+}
+
+.load-btn:hover {
+    background: #138496;
+    transform: scale(1.05);
+    box-shadow: 0 4px 8px rgba(23, 162, 184, 0.4);
+}
+
 .header-buttons {
     display: flex;
     gap: 10px;
@@ -379,6 +401,10 @@ main {
 }
 
 .save-btn:active {
+    transform: scale(0.95);
+}
+
+.load-btn:active {
     transform: scale(0.95);
 }
 


### PR DESCRIPTION
## Summary
- add save button to molecule database header
- implement modal to export molecule list to JSON
- style save button and hook up download logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f7a2df8948329a6c6d6f8db267fd5