### PR TITLE
Fix 3D ligand viewer failing to load

### DIFF
--- a/src/tests/apiService.test.js
+++ b/src/tests/apiService.test.js
@@ -29,7 +29,10 @@ describe('ApiService', () => {
   it('getCcdSdf uppercases code and fetches', async () => {
     global.fetch = mock.fn(async () => ({ ok: true, text: async () => 'sdf' }));
     const txt = await ApiService.getCcdSdf('atp');
-    assert.strictEqual(global.fetch.mock.calls[0].arguments[0], '/rcsb/ligands/view/ATP_ideal.sdf');
+    assert.strictEqual(
+      global.fetch.mock.calls[0].arguments[0],
+      'https://files.rcsb.org/ligands/view/ATP_ideal.sdf'
+    );
     assert.strictEqual(txt, 'sdf');
   });
 

--- a/src/utils/apiService.js
+++ b/src/utils/apiService.js
@@ -83,7 +83,9 @@ export default class ApiService {
    * @see https://www.ebi.ac.uk/pdbe/graph-api/pdbe_doc/ for API documentation
    */
   static getCcdSdf(ccdCode) {
-    return this.fetchText(`/rcsb/ligands/view/${ccdCode.toUpperCase()}_ideal.sdf`);
+    return this.fetchText(
+      `https://files.rcsb.org/ligands/view/${ccdCode.toUpperCase()}_ideal.sdf`
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary
- Fetch ligand SDFs directly from RCSB instead of using a dev-only proxy
- Update ApiService test to match new URL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f88dc00d08329917cdb30b635dc15