### PR TITLE
Remove 'Open on' text from PDB external link buttons

### DIFF
--- a/src/modal/PdbDetailsModal.js
+++ b/src/modal/PdbDetailsModal.js
@@ -133,8 +133,8 @@ class PdbDetailsModal {
                     </div>
                 </div>
                 <div class="pdb-external-links">
-                    <button id="open-rcsb-btn" class="view-structure-btn rcsb-btn">Open on RCSB PDB</button>
-                    <button id="open-pdbe-btn" class="view-structure-btn pdbe-btn">Open on PDBe</button>
+                    <button id="open-rcsb-btn" class="view-structure-btn rcsb-btn">RCSB PDB</button>
+                    <button id="open-pdbe-btn" class="view-structure-btn pdbe-btn">PDBe</button>
                 </div>
             </div>
             <div class="details-section">


### PR DESCRIPTION
## Summary
- Update PDB Details modal to display RCSB PDB and PDBe links without 'Open on' prefix

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f88ac6c7483299f3c12fbce995848