### PR TITLE
test: add MoleculeLoader and repository tests

### DIFF
--- a/tests/apiService.test.js
+++ b/tests/apiService.test.js
@@ -1,6 +1,6 @@
 import { describe, it, afterEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
-import ApiService from '../utils/apiService.js';
+import ApiService from '../src/utils/apiService.js';
 
 describe('ApiService', () => {
   afterEach(() => {

--- a/tests/moleculeRepository.test.js
+++ b/tests/moleculeRepository.test.js
@@ -1,0 +1,37 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import MoleculeRepository from '../src/utils/MoleculeRepository.js';
+
+describe('MoleculeRepository', () => {
+  it('adds unique molecules and prevents duplicates', () => {
+    const repo = new MoleculeRepository();
+    assert.ok(repo.addMolecule('A'));
+    assert.strictEqual(repo.addMolecule('A'), false);
+    assert.deepStrictEqual(repo.getAllMolecules(), [{ code: 'A', status: 'pending' }]);
+  });
+
+  it('removes molecules by code', () => {
+    const repo = new MoleculeRepository([{ code: 'A', status: 'pending' }]);
+    assert.ok(repo.removeMolecule('A'));
+    assert.strictEqual(repo.removeMolecule('A'), false);
+  });
+
+  it('updates molecule status', () => {
+    const repo = new MoleculeRepository([{ code: 'A', status: 'pending' }]);
+    repo.updateMoleculeStatus('A', 'loaded');
+    assert.strictEqual(repo.getMolecule('A').status, 'loaded');
+  });
+
+  it('getAllMolecules returns copy', () => {
+    const repo = new MoleculeRepository([{ code: 'A', status: 'pending' }]);
+    const arr = repo.getAllMolecules();
+    arr.push({ code: 'B', status: 'pending' });
+    assert.strictEqual(repo.getAllMolecules().length, 1);
+  });
+
+  it('deleteAllMolecules clears repository', () => {
+    const repo = new MoleculeRepository([{ code: 'A', status: 'loaded' }]);
+    repo.deleteAllMolecules();
+    assert.strictEqual(repo.getAllMolecules().length, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- move ApiService tests into new top-level tests directory
- add coverage for MoleculeRepository operations
- add MoleculeLoader tests for local/remote data loading and error handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f8c41e0f88329b9c1fa114ecede42