### PR TITLE
refactor: centralize shared constants

### DIFF
--- a/src/components/BoundLigandTable.js
+++ b/src/components/BoundLigandTable.js
@@ -1,4 +1,5 @@
 import ApiService from '../utils/apiService.js';
+import { IGNORED_LIGANDS } from '../utils/constants.js';
 
 class BoundLigandTable {
     constructor(addMolecule, showMoleculeDetails, ligandModal) {
@@ -21,7 +22,7 @@ class BoundLigandTable {
                 const ligands = data[pdbId.toLowerCase()];
 
                 if (ligands && ligands.length > 0) {
-                    const significantLigands = ligands.filter(l => !['HOH', 'ZN', 'MG', 'CA', 'NA', 'K', 'CL'].includes(l.chem_comp_id));
+                    const significantLigands = ligands.filter(l => !IGNORED_LIGANDS.includes(l.chem_comp_id));
                     const ligandsToShow = significantLigands.length > 0 ? significantLigands : ligands;
 
                     section.style.display = 'block';

--- a/src/components/FragmentLibrary.js
+++ b/src/components/FragmentLibrary.js
@@ -1,4 +1,5 @@
 import ApiService from '../utils/apiService.js';
+import { SMILES_CANVAS_WIDTH, SMILES_CANVAS_HEIGHT } from '../utils/constants.js';
 
 class FragmentLibrary {
     constructor(moleculeManager) {
@@ -157,14 +158,14 @@ class FragmentLibrary {
         setTimeout(() => {
             if ((fragment.kind === 'SMILES' || fragment.kind === 'SMARTS') && fragment.query) {
                 const canvas = document.createElement('canvas');
-                canvas.width = 200;
-                canvas.height = 150;
+                canvas.width = SMILES_CANVAS_WIDTH;
+                canvas.height = SMILES_CANVAS_HEIGHT;
                 canvasContainer.appendChild(canvas);
 
                 try {
                     const sanitizedQuery = this.sanitizeSMILES(fragment.query);
                     SmilesDrawer.parse(sanitizedQuery, function (tree) {
-                        const options = { width: 200, height: 150 };
+                        const options = { width: SMILES_CANVAS_WIDTH, height: SMILES_CANVAS_HEIGHT };
                         const smilesDrawer = new SmilesDrawer.Drawer(options);
                         smilesDrawer.draw(tree, canvas, 'light', false);
                     }, function (err) {

--- a/src/components/ProteinBrowser.js
+++ b/src/components/ProteinBrowser.js
@@ -1,10 +1,11 @@
 import ApiService from '../utils/apiService.js';
-
-const crystallizationAids = [
-    'SO4', 'PO4', 'CIT', 'EDO', 'GOL', '1PE',
-    'ACE', 'ACT', 'BME', 'DMS', 'FMT', 'IMD', 'MES',
-    'PEG', 'PGE', 'TRS'
-];
+import {
+    PDBe_CHEM_IMAGE_URL,
+    RCSB_STRUCTURE_IMAGE_URL,
+    RCSB_STRUCTURE_URL,
+    PDBe_ENTRY_BASE_URL,
+    CRYSTALLIZATION_AIDS
+} from '../utils/constants.js';
 
 class ProteinBrowser {
     constructor(moleculeManager) {
@@ -112,7 +113,7 @@ class ProteinBrowser {
         }
         const ligandHtml = ligands.slice(0, 5).map(ligand => `
             <div class="ligand-img-container">
-                <img src="https://www.ebi.ac.uk/pdbe/static/files/pdbechem_v2/${ligand.chem_comp_id}_200.svg" alt="${ligand.chem_comp_id}" title="${ligand.chem_comp_id}: ${ligand.chem_comp_name}" class="bound-ligand-img">
+                <img src="${PDBe_CHEM_IMAGE_URL}${ligand.chem_comp_id}_200.svg" alt="${ligand.chem_comp_id}" title="${ligand.chem_comp_id}: ${ligand.chem_comp_name}" class="bound-ligand-img">
                 <div class="ligand-img-overlay">
                     <button class="ligand-action-btn add-ligand" data-ccd-code="${ligand.chem_comp_id}">+</button>
                 </div>
@@ -132,11 +133,11 @@ class ProteinBrowser {
                 const title = detail.struct?.title || 'N/A';
                 const resolution = detail.rcsb_entry_info?.resolution_combined?.[0]?.toFixed(2) || 'N/A';
                 const releaseDate = detail.rcsb_accession_info?.initial_release_date ? new Date(detail.rcsb_accession_info.initial_release_date).toLocaleDateString() : 'N/A';
-                const imageUrl = `https://cdn.rcsb.org/images/structures/${pdbId.toLowerCase()}_assembly-1.jpeg`;
+                const imageUrl = `${RCSB_STRUCTURE_IMAGE_URL}${pdbId.toLowerCase()}_assembly-1.jpeg`;
 
                 let boundLigands = await this.fetchBoundLigands(pdbId);
                 if (hideAids) {
-                    boundLigands = boundLigands.filter(ligand => !crystallizationAids.includes(ligand.chem_comp_id));
+                    boundLigands = boundLigands.filter(ligand => !CRYSTALLIZATION_AIDS.includes(ligand.chem_comp_id));
                 }
 
                 row.innerHTML = `
@@ -164,12 +165,12 @@ class ProteinBrowser {
             });
             document.querySelectorAll('.view-structure-btn.rcsb-btn').forEach(button => {
                 button.addEventListener('click', (e) => {
-                    window.open(`https://www.rcsb.org/structure/${e.target.dataset.pdbId}`, '_blank');
+                    window.open(`${RCSB_STRUCTURE_URL}${e.target.dataset.pdbId}`, '_blank');
                 });
             });
             document.querySelectorAll('.view-structure-btn.pdbe-btn').forEach(button => {
                 button.addEventListener('click', (e) => {
-                    window.open(`https://www.ebi.ac.uk/pdbe/entry/pdb/${e.target.dataset.pdbId.toLowerCase()}`, '_blank');
+                    window.open(`${PDBe_ENTRY_BASE_URL}${e.target.dataset.pdbId.toLowerCase()}`, '_blank');
                 });
             });
             document.querySelectorAll('.add-ligand').forEach(button => {

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,11 @@
 import MoleculeLoader from './utils/MoleculeLoader.js';
 import MoleculeRepository from './utils/MoleculeRepository.js';
+import {
+    DEFAULT_MOLECULE_CODES,
+    STATUS,
+    NOTIFICATION_TIMEOUT,
+    NOTIFICATION_FADE_DURATION
+} from './utils/constants.js';
 import BoundLigandTable from './components/BoundLigandTable.js';
 import FragmentLibrary from './components/FragmentLibrary.js';
 import LigandModal from './modal/ligandModal.js';
@@ -9,19 +15,9 @@ import ProteinBrowser from './components/ProteinBrowser.js';
 
 class MoleculeManager {
     constructor() {
-        this.repository = new MoleculeRepository([
-            { code: 'HEM', status: 'pending' },
-            { code: 'NAD', status: 'pending' },
-            { code: 'FAD', status: 'pending' },
-            { code: 'COA', status: 'pending' },
-            { code: 'ATP', status: 'pending' },
-            { code: 'ADP', status: 'pending' },
-            { code: '355', status: 'pending' },
-            { code: 'MPV', status: 'pending' },
-            { code: 'YQD', status: 'pending' },
-            { code: 'J9N', status: 'pending' },
-            { code: 'VIA', status: 'pending' }
-        ]);
+        this.repository = new MoleculeRepository(
+            DEFAULT_MOLECULE_CODES.map(code => ({ code, status: STATUS.PENDING }))
+        );
         this.grid = null;
         this.loadingIndicator = null;
         this.cardUI = null;
@@ -204,8 +200,8 @@ function showNotification(message, type = 'info') {
             if (notification.parentNode) {
                 notification.parentNode.removeChild(notification);
             }
-        }, 300);
-    }, 3000);
+        }, NOTIFICATION_FADE_DURATION);
+    }, NOTIFICATION_TIMEOUT);
 }
 
 window.moleculeManager = moleculeManager;

--- a/src/modal/PdbDetailsModal.js
+++ b/src/modal/PdbDetailsModal.js
@@ -1,4 +1,5 @@
 import ApiService from '../utils/apiService.js';
+import { RCSB_STRUCTURE_URL, PDBe_ENTRY_BASE_URL } from '../utils/constants.js';
 
 class PdbDetailsModal {
     constructor(boundLigandTable) {
@@ -48,10 +49,10 @@ class PdbDetailsModal {
             }
 
             document.getElementById('open-rcsb-btn').addEventListener('click', () => {
-                window.open(`https://www.rcsb.org/structure/${pdbId.toUpperCase()}`, '_blank');
+                window.open(`${RCSB_STRUCTURE_URL}${pdbId.toUpperCase()}`, '_blank');
             });
             document.getElementById('open-pdbe-btn').addEventListener('click', () => {
-                window.open(`https://www.ebi.ac.uk/pdbe/entry/pdb/${pdbId.toLowerCase()}`, '_blank');
+                window.open(`${PDBe_ENTRY_BASE_URL}${pdbId.toLowerCase()}`, '_blank');
             });
 
             viewerContainer.style.display = 'block';

--- a/src/modal/ligandModal.js
+++ b/src/modal/ligandModal.js
@@ -1,4 +1,5 @@
 import ApiService from '../utils/apiService.js';
+import { AMINO_ACIDS, PDBe_CHEM_IMAGE_URL, RCSB_STRUCTURE_URL, PDBe_ENTRY_BASE_URL } from '../utils/constants.js';
 
 class LigandModal {
     constructor(moleculeManager) {
@@ -27,7 +28,7 @@ class LigandModal {
         this.detailsTitle.textContent = `Molecule Details: ${ccdCode}`;
         this.detailsCode.textContent = ccdCode;
 
-        const isAminoAcid = ['ALA','ARG','ASN','ASP','CYS','GLN','GLU','GLY','HIS','ILE','LEU','LYS','MET','PHE','PRO','SER','THR','TRP','TYR','VAL'].includes(ccdCode);
+        const isAminoAcid = AMINO_ACIDS.includes(ccdCode);
         this.detailsSource.textContent = isAminoAcid ? 'building_blocks' : 'reagents';
         this.detailsType.textContent = isAminoAcid ? 'building_block' : 'reagent';
 
@@ -280,7 +281,7 @@ class LigandModal {
 
     async load2DStructure(ccdCode, container) {
         try {
-            const imageUrl = `https://www.ebi.ac.uk/pdbe/static/files/pdbechem_v2/${ccdCode.toUpperCase()}_200.svg`;
+            const imageUrl = `${PDBe_CHEM_IMAGE_URL}${ccdCode.toUpperCase()}_200.svg`;
             const img = document.createElement('img');
             img.src = imageUrl;
             img.alt = `2D structure of ${ccdCode}`;
@@ -289,7 +290,7 @@ class LigandModal {
                 container.appendChild(img);
             };
             img.onerror = () => {
-                const altImageUrl = `https://www.ebi.ac.uk/pdbe/static/files/pdbechem_v2/${ccdCode.toLowerCase()}_200.svg`;
+                const altImageUrl = `${PDBe_CHEM_IMAGE_URL}${ccdCode.toLowerCase()}_200.svg`;
                 const altImg = document.createElement('img');
                 altImg.src = altImageUrl;
                 altImg.alt = `2D structure of ${ccdCode}`;
@@ -406,14 +407,14 @@ class LigandModal {
         rcsbButton.className = 'view-structure-btn rcsb-btn';
         rcsbButton.title = `View ${pdbId.toUpperCase()} on RCSB PDB`;
         rcsbButton.addEventListener('click', () => {
-            window.open(`https://www.rcsb.org/structure/${pdbId.toUpperCase()}`, '_blank');
+            window.open(`${RCSB_STRUCTURE_URL}${pdbId.toUpperCase()}`, '_blank');
         });
         const pdbeButton = document.createElement('button');
         pdbeButton.textContent = 'PDBe';
         pdbeButton.className = 'view-structure-btn pdbe-btn';
         pdbeButton.title = `View ${pdbId.toUpperCase()} on PDBe`;
         pdbeButton.addEventListener('click', () => {
-            window.open(`https://www.ebi.ac.uk/pdbe/entry/pdb/${pdbId.toLowerCase()}`, '_blank');
+            window.open(`${PDBe_ENTRY_BASE_URL}${pdbId.toLowerCase()}`, '_blank');
         });
         viewCell.appendChild(rcsbButton);
         viewCell.appendChild(pdbeButton);
@@ -457,14 +458,14 @@ class LigandModal {
         rcsbButton.className = 'view-structure-btn rcsb-btn';
         rcsbButton.title = `View ${pdbId.toUpperCase()} on RCSB PDB`;
         rcsbButton.addEventListener('click', () => {
-            window.open(`https://www.rcsb.org/structure/${pdbId.toUpperCase()}`, '_blank');
+            window.open(`${RCSB_STRUCTURE_URL}${pdbId.toUpperCase()}`, '_blank');
         });
         const pdbeButton = document.createElement('button');
         pdbeButton.textContent = 'PDBe';
         pdbeButton.className = 'view-structure-btn pdbe-btn';
         pdbeButton.title = `View ${pdbId.toUpperCase()} on PDBe`;
         pdbeButton.addEventListener('click', () => {
-            window.open(`https://www.ebi.ac.uk/pdbe/entry/pdb/${pdbId.toLowerCase()}`, '_blank');
+            window.open(`${PDBe_ENTRY_BASE_URL}${pdbId.toLowerCase()}`, '_blank');
         });
         viewCell.appendChild(rcsbButton);
         viewCell.appendChild(pdbeButton);

--- a/src/tests/apiService.test.js
+++ b/src/tests/apiService.test.js
@@ -1,6 +1,7 @@
 import { describe, it, afterEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import ApiService from '../utils/apiService.js';
+import { RCSB_LIGANDS_URL } from '../utils/constants.js';
 
 describe('ApiService', () => {
   afterEach(() => {
@@ -31,7 +32,7 @@ describe('ApiService', () => {
     const txt = await ApiService.getCcdSdf('atp');
     assert.strictEqual(
       global.fetch.mock.calls[0].arguments[0],
-      'https://files.rcsb.org/ligands/view/ATP_ideal.sdf'
+      `${RCSB_LIGANDS_URL}ATP_ideal.sdf`
     );
     assert.strictEqual(txt, 'sdf');
   });

--- a/src/utils/MoleculeRepository.js
+++ b/src/utils/MoleculeRepository.js
@@ -1,3 +1,5 @@
+import { STATUS } from './constants.js';
+
 class MoleculeRepository {
     constructor(initial = []) {
         this.molecules = [...initial];
@@ -7,7 +9,7 @@ class MoleculeRepository {
         if (this.molecules.find(m => m.code === code)) {
             return false;
         }
-        this.molecules.push({ code, status: 'pending' });
+        this.molecules.push({ code, status: STATUS.PENDING });
         return true;
     }
 

--- a/src/utils/apiService.js
+++ b/src/utils/apiService.js
@@ -9,6 +9,19 @@
  * @see https://www.ebi.ac.uk/pdbe/graph-api/pdbe_doc/ for PDBe API documentation
  */
 
+import {
+  LOCAL_SDF_LIBRARY_PATH,
+  FRAGMENT_LIBRARY_TSV_URL,
+  RCSB_LIGANDS_URL,
+  PDBe_COMPOUND_SIMILARITY_URL,
+  PDBe_COMPOUND_IN_PDB_URL,
+  RCSB_ENTRY_URL,
+  PDBe_PDB_SUMMARY_URL,
+  RCSB_PDB_DOWNLOAD_URL,
+  PDBe_LIGAND_MONOMERS_URL,
+  RCSB_ENTRY_GROUPS_URL,
+} from './constants.js';
+
 // In-memory cache for URL -> parsed response pairs
 const responseCache = new Map();
 
@@ -81,10 +94,10 @@ export default class ApiService {
    * - Chemical components are standardized molecular entities in the CCD
    *
    * @see https://www.ebi.ac.uk/pdbe/graph-api/pdbe_doc/ for API documentation
-   */
+  */
   static getCcdSdf(ccdCode) {
     return this.fetchText(
-      `https://files.rcsb.org/ligands/view/${ccdCode.toUpperCase()}_ideal.sdf`
+      `${RCSB_LIGANDS_URL}${ccdCode.toUpperCase()}_ideal.sdf`
     );
   }
 
@@ -111,9 +124,9 @@ export default class ApiService {
    * - SDF files contain 3D molecular coordinates in MOL format
    * - Each molecule is separated by $$$$
    * - Used for 3D molecular visualization with 3Dmol.js
-   */
+  */
   static getLocalSdfLibrary() {
-    return this.fetchText('./data/Enamine_MiniFrag_Library_80cmpds_20250123.sdf');
+    return this.fetchText(LOCAL_SDF_LIBRARY_PATH);
   }
 
   /**
@@ -132,10 +145,10 @@ export default class ApiService {
    * - TSV format with tab-separated values
    * - Contains fragments from multiple sources (PDBe, ENAMINE, DSI)
    * - Used for fragment-based drug discovery workflows
-   */
+  */
   static getFragmentLibraryTsv() {
     // Fetch fragment library TSV from GitHub
-    return this.fetchText('https://raw.githubusercontent.com/cch1999/cch1999.github.io/refs/heads/new_website/assets/files/fragment_library_ccd.tsv');
+    return this.fetchText(FRAGMENT_LIBRARY_TSV_URL);
   }
 
   /**
@@ -159,7 +172,7 @@ export default class ApiService {
    * @see https://www.ebi.ac.uk/pdbe/graph-api/pdbe_doc/ for similarity search API
    */
   static getSimilarCcds(ccdCode) {
-    return this.fetchJson(`https://www.ebi.ac.uk/pdbe/graph-api/compound/similarity/${ccdCode}`);
+    return this.fetchJson(`${PDBe_COMPOUND_SIMILARITY_URL}${ccdCode}`);
   }
 
   /**
@@ -183,7 +196,7 @@ export default class ApiService {
    * @see https://www.ebi.ac.uk/pdbe/graph-api/pdbe_doc/ for PDB search API
    */
   static getPdbEntriesForCcd(ccdCode) {
-    return this.fetchJson(`https://www.ebi.ac.uk/pdbe/graph-api/compound/in_pdb/${ccdCode}`);
+    return this.fetchJson(`${PDBe_COMPOUND_IN_PDB_URL}${ccdCode}`);
   }
 
   /**
@@ -207,7 +220,7 @@ export default class ApiService {
    * @see https://data.rcsb.org/redoc/index.html for RCSB API documentation
    */
   static getRcsbEntry(pdbId) {
-    return this.fetchJson(`https://data.rcsb.org/rest/v1/core/entry/${pdbId.toLowerCase()}`);
+    return this.fetchJson(`${RCSB_ENTRY_URL}${pdbId.toLowerCase()}`);
   }
 
   /**
@@ -231,7 +244,7 @@ export default class ApiService {
    * @see https://www.ebi.ac.uk/pdbe/graph-api/pdbe_doc/ for PDBe API documentation
    */
   static getPdbSummary(pdbId) {
-    return this.fetchJson(`https://www.ebi.ac.uk/pdbe/graph-api/pdb/summary/${pdbId}`);
+    return this.fetchJson(`${PDBe_PDB_SUMMARY_URL}${pdbId}`);
   }
 
   /**
@@ -255,7 +268,7 @@ export default class ApiService {
    * @see https://www.wwpdb.org/data/file-format for mmCIF format specification
    */
   static getPdbFile(pdbId) {
-    return this.fetchText(`https://files.rcsb.org/download/${pdbId}.pdb`);
+    return this.fetchText(`${RCSB_PDB_DOWNLOAD_URL}${pdbId}.pdb`);
   }
 
   /**
@@ -279,7 +292,7 @@ export default class ApiService {
    * @see https://www.ebi.ac.uk/pdbe/graph-api/pdbe_doc/ for bound ligands API
    */
   static getLigandMonomers(pdbId) {
-    return this.fetchJson(`https://www.ebi.ac.uk/pdbe/api/pdb/entry/ligand_monomers/${pdbId}`);
+    return this.fetchJson(`${PDBe_LIGAND_MONOMERS_URL}${pdbId}`);
   }
 
   /**
@@ -303,7 +316,7 @@ export default class ApiService {
    * @see https://data.rcsb.org/redoc/index.html for RCSB group API documentation
    */
   static getProteinGroup(groupId) {
-    return this.fetchJson(`https://data.rcsb.org/rest/v1/core/entry_groups/${groupId}`);
+    return this.fetchJson(`${RCSB_ENTRY_GROUPS_URL}${groupId}`);
   }
 
   /**

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,56 @@
+export const STATUS = {
+  PENDING: 'pending',
+  LOADING: 'loading',
+  LOADED: 'loaded',
+  ERROR: 'error'
+};
+
+export const DEFAULT_MOLECULE_CODES = [
+  'HEM',
+  'NAD',
+  'FAD',
+  'COA',
+  'ATP',
+  'ADP',
+  '355',
+  'MPV',
+  'YQD',
+  'J9N',
+  'VIA'
+];
+
+export const LOCAL_SDF_LIBRARY_PATH = './data/Enamine_MiniFrag_Library_80cmpds_20250123.sdf';
+export const FRAGMENT_LIBRARY_TSV_URL = 'https://raw.githubusercontent.com/cch1999/cch1999.github.io/refs/heads/new_website/assets/files/fragment_library_ccd.tsv';
+
+export const RCSB_LIGANDS_URL = 'https://files.rcsb.org/ligands/view/';
+export const PDBe_COMPOUND_SIMILARITY_URL = 'https://www.ebi.ac.uk/pdbe/graph-api/compound/similarity/';
+export const PDBe_COMPOUND_IN_PDB_URL = 'https://www.ebi.ac.uk/pdbe/graph-api/compound/in_pdb/';
+export const RCSB_ENTRY_URL = 'https://data.rcsb.org/rest/v1/core/entry/';
+export const PDBe_PDB_SUMMARY_URL = 'https://www.ebi.ac.uk/pdbe/graph-api/pdb/summary/';
+export const RCSB_PDB_DOWNLOAD_URL = 'https://files.rcsb.org/download/';
+export const PDBe_LIGAND_MONOMERS_URL = 'https://www.ebi.ac.uk/pdbe/api/pdb/entry/ligand_monomers/';
+export const RCSB_ENTRY_GROUPS_URL = 'https://data.rcsb.org/rest/v1/core/entry_groups/';
+
+export const IGNORED_LIGANDS = ['HOH', 'ZN', 'MG', 'CA', 'NA', 'K', 'CL'];
+
+export const AMINO_ACIDS = [
+  'ALA','ARG','ASN','ASP','CYS','GLN','GLU','GLY','HIS','ILE','LEU','LYS','MET','PHE','PRO','SER','THR','TRP','TYR','VAL'
+];
+
+export const PDBe_CHEM_IMAGE_URL = 'https://www.ebi.ac.uk/pdbe/static/files/pdbechem_v2/';
+
+export const RCSB_STRUCTURE_URL = 'https://www.rcsb.org/structure/';
+export const PDBe_ENTRY_BASE_URL = 'https://www.ebi.ac.uk/pdbe/entry/pdb/';
+export const RCSB_STRUCTURE_IMAGE_URL = 'https://cdn.rcsb.org/images/structures/';
+
+export const CRYSTALLIZATION_AIDS = [
+  'SO4', 'PO4', 'CIT', 'EDO', 'GOL', '1PE',
+  'ACE', 'ACT', 'BME', 'DMS', 'FMT', 'IMD', 'MES',
+  'PEG', 'PGE', 'TRS'
+];
+
+export const SMILES_CANVAS_WIDTH = 200;
+export const SMILES_CANVAS_HEIGHT = 150;
+
+export const NOTIFICATION_TIMEOUT = 3000;
+export const NOTIFICATION_FADE_DURATION = 300;


### PR DESCRIPTION
## Summary
- add a single constants module for statuses, URLs, default data, and UI values
- refactor utilities, components, and tests to import shared constants

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f8c9fd2e8832997774b454fbb46d6