### PR TITLE
refactor: centralize constants

### DIFF
--- a/src/components/BoundLigandTable.js
+++ b/src/components/BoundLigandTable.js
@@ -1,4 +1,5 @@
 import ApiService from '../utils/apiService.js';
+import { EXCLUDED_LIGANDS, ADD_LIGAND_DELAY_MS } from '../utils/constants.js';
 
 class BoundLigandTable {
     constructor(addMolecule, showMoleculeDetails, ligandModal) {
@@ -21,7 +22,7 @@ class BoundLigandTable {
                 const ligands = data[pdbId.toLowerCase()];
 
                 if (ligands && ligands.length > 0) {
-                    const significantLigands = ligands.filter(l => !['HOH', 'ZN', 'MG', 'CA', 'NA', 'K', 'CL'].includes(l.chem_comp_id));
+                    const significantLigands = ligands.filter(l => !EXCLUDED_LIGANDS.includes(l.chem_comp_id));
                     const ligandsToShow = significantLigands.length > 0 ? significantLigands : ligands;
 
                     section.style.display = 'block';
@@ -164,7 +165,7 @@ class BoundLigandTable {
                     addAllBtn.disabled = false;
                     addAllBtn.textContent = `Add All (${ligandList.length})`;
                 }
-            }, index * 100);
+            }, index * ADD_LIGAND_DELAY_MS);
         });
     }
 }

--- a/src/components/ProteinBrowser.js
+++ b/src/components/ProteinBrowser.js
@@ -1,10 +1,11 @@
 import ApiService from '../utils/apiService.js';
-
-const crystallizationAids = [
-    'SO4', 'PO4', 'CIT', 'EDO', 'GOL', '1PE',
-    'ACE', 'ACT', 'BME', 'DMS', 'FMT', 'IMD', 'MES',
-    'PEG', 'PGE', 'TRS'
-];
+import {
+    PD_BE_STATIC_IMAGE_BASE_URL,
+    RCSB_STRUCTURE_IMAGE_BASE_URL,
+    RCSB_STRUCTURE_BASE_URL,
+    PD_BE_ENTRY_BASE_URL,
+    CRYSTALLIZATION_AIDS
+} from '../utils/constants.js';
 
 class ProteinBrowser {
     constructor(moleculeManager) {
@@ -112,7 +113,7 @@ class ProteinBrowser {
         }
         const ligandHtml = ligands.slice(0, 5).map(ligand => `
             <div class="ligand-img-container">
-                <img src="https://www.ebi.ac.uk/pdbe/static/files/pdbechem_v2/${ligand.chem_comp_id}_200.svg" alt="${ligand.chem_comp_id}" title="${ligand.chem_comp_id}: ${ligand.chem_comp_name}" class="bound-ligand-img">
+                <img src="${PD_BE_STATIC_IMAGE_BASE_URL}/${ligand.chem_comp_id}_200.svg" alt="${ligand.chem_comp_id}" title="${ligand.chem_comp_id}: ${ligand.chem_comp_name}" class="bound-ligand-img">
                 <div class="ligand-img-overlay">
                     <button class="ligand-action-btn add-ligand" data-ccd-code="${ligand.chem_comp_id}">+</button>
                 </div>
@@ -132,11 +133,11 @@ class ProteinBrowser {
                 const title = detail.struct?.title || 'N/A';
                 const resolution = detail.rcsb_entry_info?.resolution_combined?.[0]?.toFixed(2) || 'N/A';
                 const releaseDate = detail.rcsb_accession_info?.initial_release_date ? new Date(detail.rcsb_accession_info.initial_release_date).toLocaleDateString() : 'N/A';
-                const imageUrl = `https://cdn.rcsb.org/images/structures/${pdbId.toLowerCase()}_assembly-1.jpeg`;
+                const imageUrl = `${RCSB_STRUCTURE_IMAGE_BASE_URL}/${pdbId.toLowerCase()}_assembly-1.jpeg`;
 
                 let boundLigands = await this.fetchBoundLigands(pdbId);
                 if (hideAids) {
-                    boundLigands = boundLigands.filter(ligand => !crystallizationAids.includes(ligand.chem_comp_id));
+                    boundLigands = boundLigands.filter(ligand => !CRYSTALLIZATION_AIDS.includes(ligand.chem_comp_id));
                 }
 
                 row.innerHTML = `
@@ -164,12 +165,12 @@ class ProteinBrowser {
             });
             document.querySelectorAll('.view-structure-btn.rcsb-btn').forEach(button => {
                 button.addEventListener('click', (e) => {
-                    window.open(`https://www.rcsb.org/structure/${e.target.dataset.pdbId}`, '_blank');
+                    window.open(`${RCSB_STRUCTURE_BASE_URL}/${e.target.dataset.pdbId}`, '_blank');
                 });
             });
             document.querySelectorAll('.view-structure-btn.pdbe-btn').forEach(button => {
                 button.addEventListener('click', (e) => {
-                    window.open(`https://www.ebi.ac.uk/pdbe/entry/pdb/${e.target.dataset.pdbId.toLowerCase()}`, '_blank');
+                    window.open(`${PD_BE_ENTRY_BASE_URL}/${e.target.dataset.pdbId.toLowerCase()}`, '_blank');
                 });
             });
             document.querySelectorAll('.add-ligand').forEach(button => {

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 import MoleculeLoader from './utils/MoleculeLoader.js';
 import MoleculeRepository from './utils/MoleculeRepository.js';
+import { DEFAULT_MOLECULE_CODES } from './utils/constants.js';
 import BoundLigandTable from './components/BoundLigandTable.js';
 import FragmentLibrary from './components/FragmentLibrary.js';
 import LigandModal from './modal/ligandModal.js';
@@ -9,19 +10,9 @@ import ProteinBrowser from './components/ProteinBrowser.js';
 
 class MoleculeManager {
     constructor() {
-        this.repository = new MoleculeRepository([
-            { code: 'HEM', status: 'pending' },
-            { code: 'NAD', status: 'pending' },
-            { code: 'FAD', status: 'pending' },
-            { code: 'COA', status: 'pending' },
-            { code: 'ATP', status: 'pending' },
-            { code: 'ADP', status: 'pending' },
-            { code: '355', status: 'pending' },
-            { code: 'MPV', status: 'pending' },
-            { code: 'YQD', status: 'pending' },
-            { code: 'J9N', status: 'pending' },
-            { code: 'VIA', status: 'pending' }
-        ]);
+        this.repository = new MoleculeRepository(
+            DEFAULT_MOLECULE_CODES.map(code => ({ code, status: 'pending' }))
+        );
         this.grid = null;
         this.loadingIndicator = null;
         this.cardUI = null;

--- a/src/modal/PdbDetailsModal.js
+++ b/src/modal/PdbDetailsModal.js
@@ -1,4 +1,5 @@
 import ApiService from '../utils/apiService.js';
+import { RCSB_STRUCTURE_BASE_URL, PD_BE_ENTRY_BASE_URL } from '../utils/constants.js';
 
 class PdbDetailsModal {
     constructor(boundLigandTable) {
@@ -48,10 +49,10 @@ class PdbDetailsModal {
             }
 
             document.getElementById('open-rcsb-btn').addEventListener('click', () => {
-                window.open(`https://www.rcsb.org/structure/${pdbId.toUpperCase()}`, '_blank');
+                window.open(`${RCSB_STRUCTURE_BASE_URL}/${pdbId.toUpperCase()}`, '_blank');
             });
             document.getElementById('open-pdbe-btn').addEventListener('click', () => {
-                window.open(`https://www.ebi.ac.uk/pdbe/entry/pdb/${pdbId.toLowerCase()}`, '_blank');
+                window.open(`${PD_BE_ENTRY_BASE_URL}/${pdbId.toLowerCase()}`, '_blank');
             });
 
             viewerContainer.style.display = 'block';

--- a/src/modal/ligandModal.js
+++ b/src/modal/ligandModal.js
@@ -1,4 +1,9 @@
 import ApiService from '../utils/apiService.js';
+import {
+    PD_BE_STATIC_IMAGE_BASE_URL,
+    RCSB_STRUCTURE_BASE_URL,
+    PD_BE_ENTRY_BASE_URL
+} from '../utils/constants.js';
 
 class LigandModal {
     constructor(moleculeManager) {
@@ -303,7 +308,7 @@ class LigandModal {
 
     async load2DStructure(ccdCode, container) {
         try {
-            const imageUrl = `https://www.ebi.ac.uk/pdbe/static/files/pdbechem_v2/${ccdCode.toUpperCase()}_200.svg`;
+            const imageUrl = `${PD_BE_STATIC_IMAGE_BASE_URL}/${ccdCode.toUpperCase()}_200.svg`;
             const img = document.createElement('img');
             img.src = imageUrl;
             img.alt = `2D structure of ${ccdCode}`;
@@ -312,7 +317,7 @@ class LigandModal {
                 container.appendChild(img);
             };
             img.onerror = () => {
-                const altImageUrl = `https://www.ebi.ac.uk/pdbe/static/files/pdbechem_v2/${ccdCode.toLowerCase()}_200.svg`;
+                const altImageUrl = `${PD_BE_STATIC_IMAGE_BASE_URL}/${ccdCode.toLowerCase()}_200.svg`;
                 const altImg = document.createElement('img');
                 altImg.src = altImageUrl;
                 altImg.alt = `2D structure of ${ccdCode}`;
@@ -429,14 +434,14 @@ class LigandModal {
         rcsbButton.className = 'view-structure-btn rcsb-btn';
         rcsbButton.title = `View ${pdbId.toUpperCase()} on RCSB PDB`;
         rcsbButton.addEventListener('click', () => {
-            window.open(`https://www.rcsb.org/structure/${pdbId.toUpperCase()}`, '_blank');
+            window.open(`${RCSB_STRUCTURE_BASE_URL}/${pdbId.toUpperCase()}`, '_blank');
         });
         const pdbeButton = document.createElement('button');
         pdbeButton.textContent = 'PDBe';
         pdbeButton.className = 'view-structure-btn pdbe-btn';
         pdbeButton.title = `View ${pdbId.toUpperCase()} on PDBe`;
         pdbeButton.addEventListener('click', () => {
-            window.open(`https://www.ebi.ac.uk/pdbe/entry/pdb/${pdbId.toLowerCase()}`, '_blank');
+            window.open(`${PD_BE_ENTRY_BASE_URL}/${pdbId.toLowerCase()}`, '_blank');
         });
         viewCell.appendChild(rcsbButton);
         viewCell.appendChild(pdbeButton);
@@ -480,14 +485,14 @@ class LigandModal {
         rcsbButton.className = 'view-structure-btn rcsb-btn';
         rcsbButton.title = `View ${pdbId.toUpperCase()} on RCSB PDB`;
         rcsbButton.addEventListener('click', () => {
-            window.open(`https://www.rcsb.org/structure/${pdbId.toUpperCase()}`, '_blank');
+            window.open(`${RCSB_STRUCTURE_BASE_URL}/${pdbId.toUpperCase()}`, '_blank');
         });
         const pdbeButton = document.createElement('button');
         pdbeButton.textContent = 'PDBe';
         pdbeButton.className = 'view-structure-btn pdbe-btn';
         pdbeButton.title = `View ${pdbId.toUpperCase()} on PDBe`;
         pdbeButton.addEventListener('click', () => {
-            window.open(`https://www.ebi.ac.uk/pdbe/entry/pdb/${pdbId.toLowerCase()}`, '_blank');
+            window.open(`${PD_BE_ENTRY_BASE_URL}/${pdbId.toLowerCase()}`, '_blank');
         });
         viewCell.appendChild(rcsbButton);
         viewCell.appendChild(pdbeButton);

--- a/src/utils/apiService.js
+++ b/src/utils/apiService.js
@@ -9,6 +9,19 @@
  * @see https://www.ebi.ac.uk/pdbe/graph-api/pdbe_doc/ for PDBe API documentation
  */
 
+import {
+  RCSB_LIGAND_BASE_URL,
+  RCSB_MODEL_BASE_URL,
+  FRAGMENT_LIBRARY_URL,
+  PD_BE_SIMILARITY_BASE_URL,
+  PD_BE_IN_PDB_BASE_URL,
+  RCSB_ENTRY_BASE_URL,
+  PD_BE_SUMMARY_BASE_URL,
+  RCSB_PDB_DOWNLOAD_BASE_URL,
+  PD_BE_LIGAND_MONOMERS_BASE_URL,
+  RCSB_GROUP_BASE_URL
+} from './constants.js';
+
 // In-memory cache for URL -> parsed response pairs
 const responseCache = new Map();
 
@@ -84,7 +97,7 @@ export default class ApiService {
    */
   static getCcdSdf(ccdCode) {
     return this.fetchText(
-      `https://files.rcsb.org/ligands/view/${ccdCode.toUpperCase()}_ideal.sdf`
+      `${RCSB_LIGAND_BASE_URL}/${ccdCode.toUpperCase()}_ideal.sdf`
     );
   }
 
@@ -101,7 +114,7 @@ export default class ApiService {
    */
   static getInstanceSdf(pdbId, authSeqId, labelAsymId) {
     return this.fetchText(
-      `https://models.rcsb.org/v1/${pdbId.toUpperCase()}/ligand?auth_seq_id=${authSeqId}&label_asym_id=${labelAsymId}&encoding=sdf`
+      `${RCSB_MODEL_BASE_URL}/${pdbId.toUpperCase()}/ligand?auth_seq_id=${authSeqId}&label_asym_id=${labelAsymId}&encoding=sdf`
     );
   }
   /**
@@ -123,7 +136,7 @@ export default class ApiService {
    */
   static getFragmentLibraryTsv() {
     // Fetch fragment library TSV from GitHub
-    return this.fetchText('https://raw.githubusercontent.com/cch1999/cch1999.github.io/refs/heads/new_website/assets/files/fragment_library_ccd.tsv');
+    return this.fetchText(FRAGMENT_LIBRARY_URL);
   }
 
   /**
@@ -147,7 +160,7 @@ export default class ApiService {
    * @see https://www.ebi.ac.uk/pdbe/graph-api/pdbe_doc/ for similarity search API
    */
   static getSimilarCcds(ccdCode) {
-    return this.fetchJson(`https://www.ebi.ac.uk/pdbe/graph-api/compound/similarity/${ccdCode}`);
+    return this.fetchJson(`${PD_BE_SIMILARITY_BASE_URL}/${ccdCode}`);
   }
 
   /**
@@ -171,7 +184,7 @@ export default class ApiService {
    * @see https://www.ebi.ac.uk/pdbe/graph-api/pdbe_doc/ for PDB search API
    */
   static getPdbEntriesForCcd(ccdCode) {
-    return this.fetchJson(`https://www.ebi.ac.uk/pdbe/graph-api/compound/in_pdb/${ccdCode}`);
+    return this.fetchJson(`${PD_BE_IN_PDB_BASE_URL}/${ccdCode}`);
   }
 
   /**
@@ -195,7 +208,7 @@ export default class ApiService {
    * @see https://data.rcsb.org/redoc/index.html for RCSB API documentation
    */
   static getRcsbEntry(pdbId) {
-    return this.fetchJson(`https://data.rcsb.org/rest/v1/core/entry/${pdbId.toLowerCase()}`);
+    return this.fetchJson(`${RCSB_ENTRY_BASE_URL}/${pdbId.toLowerCase()}`);
   }
 
   /**
@@ -219,7 +232,7 @@ export default class ApiService {
    * @see https://www.ebi.ac.uk/pdbe/graph-api/pdbe_doc/ for PDBe API documentation
    */
   static getPdbSummary(pdbId) {
-    return this.fetchJson(`https://www.ebi.ac.uk/pdbe/graph-api/pdb/summary/${pdbId}`);
+    return this.fetchJson(`${PD_BE_SUMMARY_BASE_URL}/${pdbId}`);
   }
 
   /**
@@ -243,7 +256,7 @@ export default class ApiService {
    * @see https://www.wwpdb.org/data/file-format for mmCIF format specification
    */
   static getPdbFile(pdbId) {
-    return this.fetchText(`https://files.rcsb.org/download/${pdbId}.pdb`);
+    return this.fetchText(`${RCSB_PDB_DOWNLOAD_BASE_URL}/${pdbId}.pdb`);
   }
 
   /**
@@ -267,7 +280,7 @@ export default class ApiService {
    * @see https://www.ebi.ac.uk/pdbe/graph-api/pdbe_doc/ for bound ligands API
    */
   static getLigandMonomers(pdbId) {
-    return this.fetchJson(`https://www.ebi.ac.uk/pdbe/api/pdb/entry/ligand_monomers/${pdbId}`);
+    return this.fetchJson(`${PD_BE_LIGAND_MONOMERS_BASE_URL}/${pdbId}`);
   }
 
   /**
@@ -291,7 +304,7 @@ export default class ApiService {
    * @see https://data.rcsb.org/redoc/index.html for RCSB group API documentation
    */
   static getProteinGroup(groupId) {
-    return this.fetchJson(`https://data.rcsb.org/rest/v1/core/entry_groups/${groupId}`);
+    return this.fetchJson(`${RCSB_GROUP_BASE_URL}/${groupId}`);
   }
 
   /**

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,34 @@
+export const RCSB_LIGAND_BASE_URL = 'https://files.rcsb.org/ligands/view';
+export const RCSB_MODEL_BASE_URL = 'https://models.rcsb.org/v1';
+export const FRAGMENT_LIBRARY_URL = 'https://raw.githubusercontent.com/cch1999/cch1999.github.io/refs/heads/new_website/assets/files/fragment_library_ccd.tsv';
+export const PD_BE_SIMILARITY_BASE_URL = 'https://www.ebi.ac.uk/pdbe/graph-api/compound/similarity';
+export const PD_BE_IN_PDB_BASE_URL = 'https://www.ebi.ac.uk/pdbe/graph-api/compound/in_pdb';
+export const RCSB_ENTRY_BASE_URL = 'https://data.rcsb.org/rest/v1/core/entry';
+export const PD_BE_SUMMARY_BASE_URL = 'https://www.ebi.ac.uk/pdbe/graph-api/pdb/summary';
+export const RCSB_PDB_DOWNLOAD_BASE_URL = 'https://files.rcsb.org/download';
+export const PD_BE_LIGAND_MONOMERS_BASE_URL = 'https://www.ebi.ac.uk/pdbe/api/pdb/entry/ligand_monomers';
+export const RCSB_GROUP_BASE_URL = 'https://data.rcsb.org/rest/v1/core/entry_groups';
+export const PD_BE_STATIC_IMAGE_BASE_URL = 'https://www.ebi.ac.uk/pdbe/static/files/pdbechem_v2';
+export const RCSB_STRUCTURE_BASE_URL = 'https://www.rcsb.org/structure';
+export const PD_BE_ENTRY_BASE_URL = 'https://www.ebi.ac.uk/pdbe/entry/pdb';
+export const RCSB_STRUCTURE_IMAGE_BASE_URL = 'https://cdn.rcsb.org/images/structures';
+export const EXCLUDED_LIGANDS = ['HOH', 'ZN', 'MG', 'CA', 'NA', 'K', 'CL'];
+export const ADD_LIGAND_DELAY_MS = 100;
+export const DEFAULT_MOLECULE_CODES = [
+  'HEM',
+  'NAD',
+  'FAD',
+  'COA',
+  'ATP',
+  'ADP',
+  '355',
+  'MPV',
+  'YQD',
+  'J9N',
+  'VIA'
+];
+export const CRYSTALLIZATION_AIDS = [
+  'SO4', 'PO4', 'CIT', 'EDO', 'GOL', '1PE',
+  'ACE', 'ACT', 'BME', 'DMS', 'FMT', 'IMD', 'MES',
+  'PEG', 'PGE', 'TRS'
+];

--- a/tests/apiService.test.js
+++ b/tests/apiService.test.js
@@ -1,6 +1,7 @@
 import { describe, it, afterEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import ApiService from '../src/utils/apiService.js';
+import { RCSB_LIGAND_BASE_URL, RCSB_MODEL_BASE_URL } from '../src/utils/constants.js';
 
 describe('ApiService', () => {
   afterEach(() => {
@@ -31,7 +32,7 @@ describe('ApiService', () => {
     const txt = await ApiService.getCcdSdf('atp');
     assert.strictEqual(
       global.fetch.mock.calls[0].arguments[0],
-      'https://files.rcsb.org/ligands/view/ATP_ideal.sdf'
+      `${RCSB_LIGAND_BASE_URL}/ATP_ideal.sdf`
     );
     assert.strictEqual(txt, 'sdf');
   });
@@ -41,7 +42,7 @@ describe('ApiService', () => {
     const txt = await ApiService.getInstanceSdf('1abc', 7, 'B');
     assert.strictEqual(
       global.fetch.mock.calls[0].arguments[0],
-      'https://models.rcsb.org/v1/1ABC/ligand?auth_seq_id=7&label_asym_id=B&encoding=sdf'
+      `${RCSB_MODEL_BASE_URL}/1ABC/ligand?auth_seq_id=7&label_asym_id=B&encoding=sdf`
     );
     assert.strictEqual(txt, 'sdf');
   });


### PR DESCRIPTION
## Summary
- extract shared URLs and static values into `constants.js`
- refactor components, services, and tests to use centralized constants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f9b7831ec8329a797eb298719da76