### PR TITLE
Add FragmentLibrary tests with DOM stub

### DIFF
--- a/tests/domStub.js
+++ b/tests/domStub.js
@@ -1,0 +1,57 @@
+class Element {
+  constructor(tagName) {
+    this.tagName = tagName.toUpperCase();
+    this.children = [];
+    this._innerHTML = '';
+    this._textContent = '';
+    this.className = '';
+    this.value = '';
+    this.checked = false;
+    this.disabled = false;
+    this.dataset = {};
+  }
+  appendChild(child) {
+    if (child && child.isFragment) {
+      this.children.push(...child.children);
+    } else {
+      this.children.push(child);
+    }
+    return child;
+  }
+  addEventListener() {}
+  querySelector() { return null; }
+  set innerHTML(val) {
+    this._innerHTML = val;
+    if (val === '') this.children = [];
+  }
+  get innerHTML() { return this._innerHTML; }
+  set textContent(val) { this._textContent = val; }
+  get textContent() {
+    return this._textContent + this.children.map(c => c.textContent || '').join('');
+  }
+}
+
+class DocumentFragment {
+  constructor() {
+    this.children = [];
+    this.isFragment = true;
+  }
+  appendChild(child) { this.children.push(child); }
+}
+
+class Document {
+  constructor() { this.elements = {}; }
+  getElementById(id) { return this.elements[id] || null; }
+  createElement(tag) { return new Element(tag); }
+  createDocumentFragment() { return new DocumentFragment(); }
+  registerElement(id, el) { this.elements[id] = el; }
+}
+
+export class JSDOM {
+  constructor() {
+    const document = new Document();
+    this.window = { document };
+  }
+}
+
+export { Element };

--- a/tests/fragmentLibrary.test.js
+++ b/tests/fragmentLibrary.test.js
@@ -1,0 +1,106 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from './domStub.js';
+import FragmentLibrary from '../src/components/FragmentLibrary.js';
+
+let dom;
+let library;
+
+const createDom = () => {
+  dom = new JSDOM();
+  const { document } = dom.window;
+  const grid = document.createElement('div');
+  const search = document.createElement('input');
+  const source = document.createElement('select');
+  const ccd = document.createElement('input');
+  document.registerElement('fragment-grid', grid);
+  document.registerElement('fragment-search', search);
+  document.registerElement('fragment-filter-source', source);
+  document.registerElement('ccd-toggle', ccd);
+  global.window = dom.window;
+  global.document = document;
+};
+
+describe('FragmentLibrary', () => {
+  beforeEach(() => {
+    createDom();
+    global.showNotification = () => {};
+    const moleculeManager = {
+      getMolecule: () => null,
+      addMolecule: () => true,
+      showMoleculeDetails: () => {}
+    };
+    library = new FragmentLibrary(moleculeManager);
+    library.init();
+    // Stub createFragmentCard to simplify DOM interactions
+    library.createFragmentCard = (fragment) => {
+      const el = document.createElement('div');
+      el.textContent = fragment.name;
+      return el;
+    };
+  });
+
+  it('sanitizeSMILES strips invalid characters', () => {
+    const input = 'C1=CC*?C1';
+    const sanitized = library.sanitizeSMILES(input);
+    assert.strictEqual(sanitized, 'C1=CCC1');
+  });
+
+  it('addFragment adds valid data and returns true', () => {
+    library.fragments = [];
+    library.renderFragments = () => {};
+    const result = library.addFragment({ name: 'Frag', query: 'C', description: 'd', source: 'custom' });
+    assert.strictEqual(result, true);
+    assert.strictEqual(library.fragments.length, 1);
+    assert.strictEqual(library.fragments[0].name, 'Frag');
+  });
+
+  it('addFragment missing name returns false and does not modify list', () => {
+    library.fragments = [];
+    library.renderFragments = () => {};
+    const result = library.addFragment({ query: 'C' });
+    assert.strictEqual(result, false);
+    assert.strictEqual(library.fragments.length, 0);
+  });
+
+  it('addFragment missing query returns false and does not modify list', () => {
+    library.fragments = [];
+    library.renderFragments = () => {};
+    const result = library.addFragment({ name: 'Frag' });
+    assert.strictEqual(result, false);
+    assert.strictEqual(library.fragments.length, 0);
+  });
+
+  it('renderFragments filters by search text, source filter, and CCD toggle', () => {
+    library.fragments = [
+      { id: '1', name: 'Alpha', source: 'custom', in_ccd: false, kind: 'OTHER', query: '' },
+      { id: '2', name: 'Beta', source: 'pdb', in_ccd: true, ccd: 'BTA', kind: 'OTHER', query: '' },
+      { id: '3', name: 'Gamma', source: 'pdb', in_ccd: false, kind: 'OTHER', query: '' }
+    ];
+
+    // Search filter
+    library.searchInput.value = 'al';
+    library.sourceFilter.value = 'all';
+    library.ccdToggle.checked = false;
+    library.renderFragments();
+    assert.strictEqual(library.grid.children.length, 1);
+    assert.match(library.grid.textContent, /Alpha/);
+
+    // Source filter
+    library.grid.innerHTML = '';
+    library.searchInput.value = '';
+    library.sourceFilter.value = 'custom';
+    library.ccdToggle.checked = false;
+    library.renderFragments();
+    assert.strictEqual(library.grid.children.length, 1);
+    assert.match(library.grid.textContent, /Alpha/);
+
+    // CCD toggle
+    library.grid.innerHTML = '';
+    library.sourceFilter.value = 'all';
+    library.ccdToggle.checked = true;
+    library.renderFragments();
+    assert.strictEqual(library.grid.children.length, 1);
+    assert.match(library.grid.textContent, /Beta/);
+  });
+});


### PR DESCRIPTION
## Summary
- create a simple DOM stub to mimic JSDOM for unit testing
- test `sanitizeSMILES` to strip unsupported characters
- verify `addFragment` and `renderFragments` behaviors with mocked elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f984f7b0083298d80fc21237f0773