### PR TITLE
Add styled Add Molecule dialog with validation

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,14 +172,15 @@
             </div>
             <div class="modal-body">
                 <label for="molecule-code">CCD Code:</label>
-                <input type="text" id="molecule-code" placeholder="Enter 3-letter code (e.g., ATP)" maxlength="10">
+                <input type="text" id="molecule-code" placeholder="Enter 3-letter code (e.g., ATP)" maxlength="3">
                 <p class="help-text">Enter a Chemical Component Dictionary (CCD) code</p>
+                <p class="error-text" id="ccd-error"></p>
             </div>
             <div class="modal-footer">
-                <button id="feeling-lucky-btn" class="btn-secondary">I'm Feeling Lucky</button>
+                <button id="feeling-lucky-btn" class="btn-secondary" disabled>I'm Feeling Lucky</button>
                 <div>
                     <button id="cancel-btn" class="btn-secondary">Cancel</button>
-                    <button id="confirm-add-btn" class="btn-primary">Add Molecule</button>
+                    <button id="confirm-add-btn" class="btn-primary" disabled>Add Molecule</button>
                 </div>
             </div>
         </div>

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ import FragmentLibrary from './components/FragmentLibrary.js';
 import LigandModal from './modal/ligandModal.js';
 import MoleculeCard from './components/MoleculeCard.js';
 import PdbDetailsModal from './modal/PdbDetailsModal.js';
+import AddMoleculeModal from './modal/AddMoleculeModal.js';
 import ProteinBrowser from './components/ProteinBrowser.js';
 
 class MoleculeManager {
@@ -29,6 +30,7 @@ class MoleculeManager {
         this.ligandModal = null;
         this.boundLigandTable = null;
         this.pdbDetailsModal = null;
+        this.addModal = null;
     }
 
     init() {
@@ -48,16 +50,11 @@ class MoleculeManager {
             this.ligandModal
         );
         this.pdbDetailsModal = new PdbDetailsModal(this.boundLigandTable);
+        this.addModal = new AddMoleculeModal(this);
 
         document.getElementById('add-molecule-btn').addEventListener('click', () => {
-            const code = prompt('Enter CCD Code').toUpperCase();
-            if (code) {
-                const success = this.addMolecule(code);
-                if (success) {
-                    showNotification(`Adding molecule ${code}...`, 'success');
-                } else {
-                    showNotification(`Molecule ${code} already exists`, 'info');
-                }
+            if (this.addModal) {
+                this.addModal.open();
             }
         });
 

--- a/src/modal/AddMoleculeModal.js
+++ b/src/modal/AddMoleculeModal.js
@@ -1,0 +1,85 @@
+class AddMoleculeModal {
+    constructor(moleculeManager) {
+        this.moleculeManager = moleculeManager;
+        this.modal = document.getElementById('add-molecule-modal');
+        this.codeInput = document.getElementById('molecule-code');
+        this.errorText = document.getElementById('ccd-error');
+        this.confirmBtn = document.getElementById('confirm-add-btn');
+        this.cancelBtn = document.getElementById('cancel-btn');
+        this.closeBtn = document.getElementById('close-modal');
+        this.luckyBtn = document.getElementById('feeling-lucky-btn');
+
+        if (this.cancelBtn) {
+            this.cancelBtn.addEventListener('click', () => this.close());
+        }
+        if (this.closeBtn) {
+            this.closeBtn.addEventListener('click', () => this.close());
+        }
+        window.addEventListener('click', (e) => {
+            if (e.target === this.modal) {
+                this.close();
+            }
+        });
+
+        if (this.codeInput) {
+            this.codeInput.addEventListener('input', () => this.handleInput());
+        }
+        if (this.confirmBtn) {
+            this.confirmBtn.addEventListener('click', () => this.handleSubmit());
+        }
+        if (this.luckyBtn) {
+            this.luckyBtn.disabled = true;
+        }
+    }
+
+    open() {
+        if (this.modal) {
+            this.reset();
+            this.modal.style.display = 'block';
+            this.codeInput.focus();
+        }
+    }
+
+    close() {
+        if (this.modal) {
+            this.modal.style.display = 'none';
+        }
+    }
+
+    reset() {
+        if (this.codeInput) {
+            this.codeInput.value = '';
+        }
+        if (this.errorText) {
+            this.errorText.textContent = '';
+        }
+        if (this.confirmBtn) {
+            this.confirmBtn.disabled = true;
+        }
+    }
+
+    handleInput() {
+        let value = this.codeInput.value.toUpperCase();
+        this.codeInput.value = value;
+        const isValid = /^[A-Z0-9]{3}$/.test(value);
+        if (this.errorText) {
+            this.errorText.textContent = isValid ? '' : 'Code must be 3 alphanumeric characters.';
+        }
+        if (this.confirmBtn) {
+            this.confirmBtn.disabled = !isValid;
+        }
+    }
+
+    handleSubmit() {
+        const code = this.codeInput.value.toUpperCase();
+        const success = this.moleculeManager.addMolecule(code);
+        if (success) {
+            window.showNotification(`Adding molecule ${code}...`, 'success');
+        } else {
+            window.showNotification(`Molecule ${code} already exists`, 'info');
+        }
+        this.close();
+    }
+}
+
+export default AddMoleculeModal;

--- a/style.css
+++ b/style.css
@@ -463,6 +463,12 @@ main {
     font-style: italic;
 }
 
+.error-text {
+    margin: 5px 0 0;
+    font-size: 14px;
+    color: #f44336;
+}
+
 .modal-footer {
     display: flex;
     justify-content: space-between;
@@ -497,6 +503,11 @@ main {
 
 .btn-primary:hover {
     background: #5a37c7;
+}
+
+.btn-primary:disabled {
+    background: #bfaaf7;
+    cursor: not-allowed;
 }
 
 .btn-secondary {


### PR DESCRIPTION
## Summary
- Replace prompt-based molecule input with a polished modal dialog
- Validate CCD codes and disable submission until input is valid
- Add error styling and disabled button states for clearer feedback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f9d4b6fa08329b359067df2cd83ac