### PR TITLE
feat: prepare for pdb instance molecules

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,6 +175,15 @@
                 <input type="text" id="molecule-code" placeholder="Enter 3-letter code (e.g., ATP)" maxlength="3">
                 <p class="help-text">Enter a Chemical Component Dictionary (CCD) code</p>
                 <p class="error-text" id="ccd-error"></p>
+
+                <label for="pdb-id" style="margin-top:20px;">PDB Instance:</label>
+                <div class="instance-inputs">
+                    <input type="text" id="pdb-id" placeholder="PDB ID" maxlength="4">
+                    <input type="text" id="auth-seq-id" placeholder="Residue #">
+                    <input type="text" id="label-asym-id" placeholder="Chain" maxlength="2">
+                </div>
+                <p class="help-text">Optional: specify PDB ID, residue number and chain to add a bound ligand</p>
+                <p class="error-text" id="instance-error"></p>
             </div>
             <div class="modal-footer">
                 <button id="feeling-lucky-btn" class="btn-secondary" disabled>I'm Feeling Lucky</button>

--- a/src/components/MoleculeCard.js
+++ b/src/components/MoleculeCard.js
@@ -7,11 +7,12 @@ class MoleculeCard {
         this.draggedElement = null;
     }
 
-    createMoleculeCardFromSmiles(smiles, ccdCode) {
+    createMoleculeCardFromSmiles(smiles, ccdCode, id = ccdCode) {
         const card = document.createElement('div');
         card.className = 'molecule-card';
         card.draggable = true;
         card.setAttribute('data-molecule-code', ccdCode);
+        card.setAttribute('data-molecule-id', id);
 
         const dragHandle = document.createElement('div');
         dragHandle.className = 'drag-handle';
@@ -62,11 +63,12 @@ class MoleculeCard {
         `;
     }
 
-    createMoleculeCard(data, ccdCode, format = 'sdf') {
+    createMoleculeCard(data, ccdCode, format = 'sdf', id = ccdCode) {
         const card = document.createElement('div');
         card.className = 'molecule-card';
         card.draggable = true;
         card.setAttribute('data-molecule-code', ccdCode);
+        card.setAttribute('data-molecule-id', id);
 
         const dragHandle = document.createElement('div');
         dragHandle.className = 'drag-handle';
@@ -114,11 +116,12 @@ class MoleculeCard {
         }, 100);
     }
 
-    createNotFoundCard(ccdCode, message = 'Not found') {
+    createNotFoundCard(ccdCode, message = 'Not found', id = ccdCode) {
         const card = document.createElement('div');
         card.className = 'molecule-card';
         card.draggable = true;
         card.setAttribute('data-molecule-code', ccdCode);
+        card.setAttribute('data-molecule-id', id);
 
         const dragHandle = document.createElement('div');
         dragHandle.className = 'drag-handle';

--- a/src/main.js
+++ b/src/main.js
@@ -82,6 +82,10 @@ class MoleculeManager {
         return added;
     }
 
+    addPdbInstance({ code, pdbId, authSeqId, labelAsymId }) {
+        return this.addMolecule({ code, pdbId, authSeqId, labelAsymId });
+    }
+
     deleteMolecule(code) {
         if (this.repository.removeMolecule(code)) {
             const card = this.grid.querySelector(`[data-molecule-code="${code}"]`);

--- a/src/modal/AddMoleculeModal.js
+++ b/src/modal/AddMoleculeModal.js
@@ -9,6 +9,11 @@ class AddMoleculeModal {
         this.closeBtn = document.getElementById('close-modal');
         this.luckyBtn = document.getElementById('feeling-lucky-btn');
 
+        this.pdbIdInput = document.getElementById('pdb-id');
+        this.authSeqIdInput = document.getElementById('auth-seq-id');
+        this.labelAsymIdInput = document.getElementById('label-asym-id');
+        this.instanceError = document.getElementById('instance-error');
+
         if (this.cancelBtn) {
             this.cancelBtn.addEventListener('click', () => this.close());
         }
@@ -23,6 +28,15 @@ class AddMoleculeModal {
 
         if (this.codeInput) {
             this.codeInput.addEventListener('input', () => this.handleInput());
+        }
+        if (this.pdbIdInput) {
+            this.pdbIdInput.addEventListener('input', () => this.handleInstanceInput());
+        }
+        if (this.authSeqIdInput) {
+            this.authSeqIdInput.addEventListener('input', () => this.handleInstanceInput());
+        }
+        if (this.labelAsymIdInput) {
+            this.labelAsymIdInput.addEventListener('input', () => this.handleInstanceInput());
         }
         if (this.confirmBtn) {
             this.confirmBtn.addEventListener('click', () => this.handleSubmit());
@@ -53,6 +67,18 @@ class AddMoleculeModal {
         if (this.errorText) {
             this.errorText.textContent = '';
         }
+        if (this.instanceError) {
+            this.instanceError.textContent = '';
+        }
+        if (this.pdbIdInput) {
+            this.pdbIdInput.value = '';
+        }
+        if (this.authSeqIdInput) {
+            this.authSeqIdInput.value = '';
+        }
+        if (this.labelAsymIdInput) {
+            this.labelAsymIdInput.value = '';
+        }
         if (this.confirmBtn) {
             this.confirmBtn.disabled = true;
         }
@@ -70,13 +96,43 @@ class AddMoleculeModal {
         }
     }
 
+    handleInstanceInput() {
+        if (this.instanceError) {
+            this.instanceError.textContent = '';
+        }
+    }
+
     handleSubmit() {
         const code = this.codeInput.value.toUpperCase();
-        const success = this.moleculeManager.addMolecule(code);
-        if (success) {
-            window.showNotification(`Adding molecule ${code}...`, 'success');
+        const pdbId = this.pdbIdInput.value.trim().toUpperCase();
+        const authSeqId = this.authSeqIdInput.value.trim();
+        const labelAsymId = this.labelAsymIdInput.value.trim().toUpperCase();
+
+        if (pdbId || authSeqId || labelAsymId) {
+            if (!(pdbId && authSeqId && labelAsymId)) {
+                if (this.instanceError) {
+                    this.instanceError.textContent = 'PDB ID, residue number and chain are required.';
+                }
+                return;
+            }
+            const success = this.moleculeManager.addPdbInstance({
+                code,
+                pdbId,
+                authSeqId,
+                labelAsymId
+            });
+            if (success) {
+                window.showNotification(`Adding ligand ${code} from ${pdbId}...`, 'success');
+            } else {
+                window.showNotification(`Ligand ${code} instance already exists`, 'info');
+            }
         } else {
-            window.showNotification(`Molecule ${code} already exists`, 'info');
+            const success = this.moleculeManager.addMolecule(code);
+            if (success) {
+                window.showNotification(`Adding molecule ${code}...`, 'success');
+            } else {
+                window.showNotification(`Molecule ${code} already exists`, 'info');
+            }
         }
         this.close();
     }

--- a/src/utils/MoleculeRepository.js
+++ b/src/utils/MoleculeRepository.js
@@ -1,14 +1,27 @@
 class MoleculeRepository {
     constructor(initial = []) {
-        this.molecules = [...initial];
+        this.molecules = initial.map(m => ({ ...m, id: this.generateId(m) }));
+    }
+
+    generateId(data) {
+        if (typeof data === 'string') return data;
+        const { code, pdbId, authSeqId, labelAsymId } = data;
+        if (pdbId && authSeqId && labelAsymId) {
+            return `${pdbId}_${labelAsymId}_${authSeqId}_${code}`;
+        }
+        return code;
     }
 
     addMolecule(data) {
-        const code = typeof data === 'string' ? data : data.code;
-        if (this.molecules.find(m => m.code === code)) {
+        const id = this.generateId(data);
+        if (this.molecules.find(m => m.id === id)) {
             return false;
         }
-        const molecule = { code, status: 'pending' };
+        const molecule = {
+            code: typeof data === 'string' ? data : data.code,
+            status: 'pending',
+            id,
+        };
         if (data && typeof data === 'object') {
             Object.assign(molecule, data);
         }
@@ -16,8 +29,10 @@ class MoleculeRepository {
         return true;
     }
 
-    removeMolecule(code) {
-        const index = this.molecules.findIndex(m => m.code === code);
+    removeMolecule(identifier) {
+        const index = this.molecules.findIndex(
+            m => m.id === identifier || m.code === identifier
+        );
         if (index === -1) return false;
         this.molecules.splice(index, 1);
         return true;
@@ -27,12 +42,14 @@ class MoleculeRepository {
         this.molecules = [];
     }
 
-    getMolecule(code) {
-        return this.molecules.find(m => m.code === code);
+    getMolecule(identifier) {
+        return this.molecules.find(
+            m => m.id === identifier || m.code === identifier
+        );
     }
 
-    updateMoleculeStatus(code, status) {
-        const molecule = this.getMolecule(code);
+    updateMoleculeStatus(identifier, status) {
+        const molecule = this.getMolecule(identifier);
         if (molecule) {
             molecule.status = status;
         }

--- a/style.css
+++ b/style.css
@@ -456,6 +456,16 @@ main {
     box-shadow: 0 0 0 3px rgba(110, 69, 226, 0.1);
 }
 
+.instance-inputs {
+    display: flex;
+    gap: 10px;
+    margin-top: 5px;
+}
+
+.instance-inputs input {
+    flex: 1;
+}
+
 .help-text {
     margin: 10px 0 0;
     font-size: 14px;

--- a/tests/moleculeRepository.test.js
+++ b/tests/moleculeRepository.test.js
@@ -7,7 +7,9 @@ describe('MoleculeRepository', () => {
     const repo = new MoleculeRepository();
     assert.ok(repo.addMolecule('A'));
     assert.strictEqual(repo.addMolecule('A'), false);
-    assert.deepStrictEqual(repo.getAllMolecules(), [{ code: 'A', status: 'pending' }]);
+    assert.deepStrictEqual(repo.getAllMolecules(), [
+      { code: 'A', status: 'pending', id: 'A' },
+    ]);
   });
 
   it('stores instance metadata when provided', () => {
@@ -19,7 +21,22 @@ describe('MoleculeRepository', () => {
       pdbId: '1ABC',
       authSeqId: '5',
       labelAsymId: 'A',
+      id: '1ABC_A_5_B',
     });
+  });
+
+  it('allows same code for different pdb instances', () => {
+    const repo = new MoleculeRepository();
+    assert.ok(repo.addMolecule('DUP'));
+    assert.ok(
+      repo.addMolecule({
+        code: 'DUP',
+        pdbId: '9XYZ',
+        authSeqId: '1',
+        labelAsymId: 'A',
+      })
+    );
+    assert.strictEqual(repo.getAllMolecules().length, 2);
   });
 
   it('removes molecules by code', () => {


### PR DESCRIPTION
## Summary
- allow repository to assign unique IDs and store pdb instance metadata
- expose `addPdbInstance` helper in `MoleculeManager`
- add molecule id handling to card UI
- extend repository tests for pdb instance molecules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fa153be288329b6a0f6e0f9d19564