### PR TITLE
refactor: inject dependencies into FragmentLibrary

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -151,7 +151,10 @@ class MoleculeManager {
 const moleculeManager = new MoleculeManager().init();
 moleculeManager.loadAllMolecules();
 
-const fragmentLibrary = new FragmentLibrary(moleculeManager).init();
+const fragmentLibrary = new FragmentLibrary(moleculeManager, {
+    notify: showNotification,
+    smilesDrawer: window.SmilesDrawer
+}).init();
 fragmentLibrary.loadFragments();
 
 const proteinBrowser = new ProteinBrowser(moleculeManager).init();

--- a/tests/fragmentLibrary.test.js
+++ b/tests/fragmentLibrary.test.js
@@ -24,13 +24,13 @@ const createDom = () => {
 describe('FragmentLibrary', () => {
   beforeEach(() => {
     createDom();
-    global.showNotification = () => {};
     const moleculeManager = {
       getMolecule: () => null,
       addMolecule: () => true,
       showMoleculeDetails: () => {}
     };
-    library = new FragmentLibrary(moleculeManager);
+    const smilesStub = { parse: () => {}, Drawer: class { draw() {} } };
+    library = new FragmentLibrary(moleculeManager, { notify: () => {}, smilesDrawer: smilesStub });
     library.init();
     // Stub createFragmentCard to simplify DOM interactions
     library.createFragmentCard = (fragment) => {


### PR DESCRIPTION
## Summary
- allow `FragmentLibrary` to accept injected `notify` and `smilesDrawer` dependencies
- use the injected notify/drawer instead of globals
- wire `main.js` and tests to provide the notification and drawer globals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fa1f8c0988329a6d9f84e62d45e94