### PR TITLE
ci: add preview deployment for PRs

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,15 +1,14 @@
-name: Deploy to GitHub Pages
+name: Deploy Preview
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
 
 permissions:
   contents: write
 
 jobs:
   build-and-deploy:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
 
     steps:
@@ -27,9 +26,10 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Deploy
+      - name: Deploy preview
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
+          destination_dir: pr-preview/${{ github.event.number }}
           keep_files: true


### PR DESCRIPTION
## Summary
- preview deploy created per PR in `gh-pages/pr-preview/<PR number>`
- keep preview builds when deploying main site

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fac398a508329a760ed2e67e9aab4