### PR TITLE
feat: add molecule export helper and UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,6 +201,32 @@
         </div>
     </div>
 
+    <!-- Export Modal -->
+    <div id="export-modal" class="modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3>Export Molecules</h3>
+                <span class="close" id="close-export-modal">&times;</span>
+            </div>
+            <div class="modal-body">
+                <label for="export-filename">File Name:</label>
+                <input type="text" id="export-filename" placeholder="molecules.sdf">
+                <div class="toggle-switch" style="margin-top:20px;">
+                    <input type="checkbox" id="export-remove-h-toggle" class="toggle-switch-checkbox">
+                    <label class="toggle-switch-label" for="export-remove-h-toggle">
+                        <span class="toggle-switch-inner"></span>
+                        <span class="toggle-switch-switch"></span>
+                    </label>
+                    <span>Remove hydrogens</span>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button id="cancel-export-btn" class="btn-secondary">Cancel</button>
+                <button id="confirm-export-btn" class="btn-primary">Export</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Molecule Details Modal -->
     <div id="molecule-details-modal" class="modal">
         <div class="modal-content details-modal">

--- a/index.html
+++ b/index.html
@@ -56,6 +56,12 @@
                                     d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z" />
                             </svg>
                         </button>
+                        <button id="export-btn" class="export-btn" title="Export all molecules">
+                            <svg viewBox="0 0 24 24" width="18" height="18">
+                                <path fill="currentColor"
+                                    d="M5 20h14v-2H5m14-9h-4V3H9v6H5l7 7 7-7Z" />
+                            </svg>
+                        </button>
                     </div>
                 </div>
                 <div id="molecule-grid" class="molecule-grid">

--- a/src/main.js
+++ b/src/main.js
@@ -55,21 +55,40 @@ class MoleculeManager {
             }
         });
 
+        const exportModal = document.getElementById('export-modal');
+        const exportFilenameInput = document.getElementById('export-filename');
+        const exportRemoveH = document.getElementById('export-remove-h-toggle');
+        const closeExport = () => (exportModal.style.display = 'none');
+
         document.getElementById('export-btn').addEventListener('click', () => {
-            const sdf = this.repository.exportToSdf();
+            if (exportModal) {
+                exportFilenameInput.value = 'molecules';
+                exportRemoveH.checked = false;
+                exportModal.style.display = 'block';
+            }
+        });
+        document.getElementById('cancel-export-btn').addEventListener('click', closeExport);
+        document.getElementById('close-export-modal').addEventListener('click', closeExport);
+        document.getElementById('confirm-export-btn').addEventListener('click', () => {
+            const sdf = this.repository.exportToSdf({ removeHydrogens: exportRemoveH.checked });
             if (!sdf) {
                 showNotification('No SDF data to export', 'info');
                 return;
+            }
+            let filename = exportFilenameInput.value.trim() || 'molecules';
+            if (!filename.toLowerCase().endsWith('.sdf')) {
+                filename += '.sdf';
             }
             const blob = new Blob([sdf], { type: 'chemical/x-mdl-sdfile' });
             const url = URL.createObjectURL(blob);
             const a = document.createElement('a');
             a.href = url;
-            a.download = 'molecules.sdf';
+            a.download = filename;
             document.body.appendChild(a);
             a.click();
             document.body.removeChild(a);
             URL.revokeObjectURL(url);
+            closeExport();
         });
 
         // Tab switching for Molecules, Fragments, Proteins

--- a/src/main.js
+++ b/src/main.js
@@ -55,6 +55,23 @@ class MoleculeManager {
             }
         });
 
+        document.getElementById('export-btn').addEventListener('click', () => {
+            const sdf = this.repository.exportToSdf();
+            if (!sdf) {
+                showNotification('No SDF data to export', 'info');
+                return;
+            }
+            const blob = new Blob([sdf], { type: 'chemical/x-mdl-sdfile' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'molecules.sdf';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        });
+
         // Tab switching for Molecules, Fragments, Proteins
         const tabButtons = document.querySelectorAll('.tab-button');
         const panels = [

--- a/src/utils/MoleculeLoader.js
+++ b/src/utils/MoleculeLoader.js
@@ -35,6 +35,10 @@ class MoleculeLoader {
                 throw new Error('Received empty or invalid SDF data.');
             }
             this.repository.updateMoleculeStatus(code, 'loaded');
+            const molecule = this.repository.getMolecule(code);
+            if (molecule) {
+                molecule.sdf = sdfData;
+            }
             this.cardUI.createMoleculeCard(sdfData, code, 'sdf');
         } catch (error) {
             console.error(`Could not fetch or process data for ${code}:`, error);

--- a/src/utils/MoleculeRepository.js
+++ b/src/utils/MoleculeRepository.js
@@ -62,6 +62,19 @@ class MoleculeRepository {
     clearAll() {
         this.molecules = [];
     }
+
+    exportToSdf() {
+        return this.molecules
+            .filter(m => m.sdf)
+            .map(m => {
+                let sdf = m.sdf.trimEnd();
+                if (!sdf.endsWith('$$$$')) {
+                    sdf += '\n$$$$';
+                }
+                return sdf;
+            })
+            .join('\n');
+    }
 }
 
 export default MoleculeRepository;

--- a/src/utils/MoleculeRepository.js
+++ b/src/utils/MoleculeRepository.js
@@ -63,11 +63,67 @@ class MoleculeRepository {
         this.molecules = [];
     }
 
-    exportToSdf() {
+    removeHydrogensFromSdf(sdf) {
+        const lines = sdf.split(/\r?\n/);
+        if (lines.length < 4) return sdf;
+
+        const counts = lines[3];
+        const atomCount = parseInt(counts.slice(0, 3));
+        const bondCount = parseInt(counts.slice(3, 6));
+        const atomLines = lines.slice(4, 4 + atomCount);
+        const bondLines = lines.slice(4 + atomCount, 4 + atomCount + bondCount);
+        const otherLines = lines.slice(4 + atomCount + bondCount);
+
+        const keptIndices = [];
+        const newAtomLines = [];
+
+        atomLines.forEach((line, idx) => {
+            const element = line.slice(31, 34).trim();
+            if (element !== 'H') {
+                keptIndices.push(idx + 1); // original 1-indexed
+                newAtomLines.push(line);
+            }
+        });
+
+        const indexMap = new Map();
+        keptIndices.forEach((oldIdx, newIdx) => {
+            indexMap.set(oldIdx, newIdx + 1); // map old -> new
+        });
+
+        const newBondLines = [];
+        bondLines.forEach(line => {
+            const a1 = parseInt(line.slice(0, 3));
+            const a2 = parseInt(line.slice(3, 6));
+            if (indexMap.has(a1) && indexMap.has(a2)) {
+                const na1 = String(indexMap.get(a1)).padStart(3, '0');
+                const na2 = String(indexMap.get(a2)).padStart(3, '0');
+                newBondLines.push(na1 + na2 + line.slice(6));
+            }
+        });
+
+        const newCounts =
+            String(newAtomLines.length).padStart(3, '0') +
+            String(newBondLines.length).padStart(3, '0') +
+            counts.slice(6);
+
+        return [
+            ...lines.slice(0, 3),
+            newCounts,
+            ...newAtomLines,
+            ...newBondLines,
+            ...otherLines,
+        ].join('\n');
+    }
+
+    exportToSdf(options = {}) {
+        const { removeHydrogens = false } = options;
         return this.molecules
             .filter(m => m.sdf)
             .map(m => {
-                let sdf = m.sdf.trimEnd();
+                let sdf = removeHydrogens
+                    ? this.removeHydrogensFromSdf(m.sdf)
+                    : m.sdf;
+                sdf = sdf.trimEnd();
                 if (!sdf.endsWith('$$$$')) {
                     sdf += '\n$$$$';
                 }

--- a/style.css
+++ b/style.css
@@ -310,6 +310,32 @@ main {
     transform: scale(0.95);
 }
 
+.export-btn {
+    background: #3498db;
+    color: white;
+    border: none;
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    font-size: 18px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.3s ease;
+    box-shadow: 0 2px 4px rgba(52, 152, 219, 0.3);
+}
+
+.export-btn:hover {
+    background: #2980b9;
+    transform: scale(1.05);
+    box-shadow: 0 4px 8px rgba(52, 152, 219, 0.4);
+}
+
+.export-btn:active {
+    transform: scale(0.95);
+}
+
 .add-fragment-btn {
     background-color: #28a745;
     color: white;

--- a/tests/moleculeRepository.test.js
+++ b/tests/moleculeRepository.test.js
@@ -63,4 +63,13 @@ describe('MoleculeRepository', () => {
     repo.deleteAllMolecules();
     assert.strictEqual(repo.getAllMolecules().length, 0);
   });
+
+  it('exportToSdf concatenates SDF records', () => {
+    const repo = new MoleculeRepository([
+      { code: 'A', status: 'loaded', sdf: 'A\n$$$$' },
+      { code: 'B', status: 'loaded', sdf: 'B\n$$$$' },
+    ]);
+    const result = repo.exportToSdf();
+    assert.strictEqual(result, 'A\n$$$$\nB\n$$$$');
+  });
 });

--- a/tests/moleculeRepository.test.js
+++ b/tests/moleculeRepository.test.js
@@ -64,12 +64,23 @@ describe('MoleculeRepository', () => {
     assert.strictEqual(repo.getAllMolecules().length, 0);
   });
 
-  it('exportToSdf concatenates SDF records', () => {
-    const repo = new MoleculeRepository([
-      { code: 'A', status: 'loaded', sdf: 'A\n$$$$' },
-      { code: 'B', status: 'loaded', sdf: 'B\n$$$$' },
-    ]);
-    const result = repo.exportToSdf();
-    assert.strictEqual(result, 'A\n$$$$\nB\n$$$$');
+    it('exportToSdf concatenates SDF records', () => {
+      const repo = new MoleculeRepository([
+        { code: 'A', status: 'loaded', sdf: 'A\n$$$$' },
+        { code: 'B', status: 'loaded', sdf: 'B\n$$$$' },
+      ]);
+      const result = repo.exportToSdf();
+      assert.strictEqual(result, 'A\n$$$$\nB\n$$$$');
+    });
+
+    it('exportToSdf removes hydrogens when requested', () => {
+      const sdf = `Example\n  test\n\n  3  2  0  0  0  0            999 V2000\n    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n    1.0000    0.0000    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0\n   -1.0000    0.0000    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0\n  1  2  1  0  0  0  0\n  1  3  1  0  0  0  0\nM  END\n$$$$`;
+      const repo = new MoleculeRepository([{ code: 'X', status: 'loaded', sdf }]);
+      const result = repo.exportToSdf({ removeHydrogens: true });
+      const lines = result.split('\n');
+      assert.strictEqual(parseInt(lines[3].slice(0, 3)), 1);
+      assert.strictEqual(parseInt(lines[3].slice(3, 6)), 0);
+      assert.ok(!result.includes(' H '));
+      assert.ok(result.endsWith('$$$$'));
+    });
   });
-});


### PR DESCRIPTION
## Summary
- add exportToSdf helper for concatenating stored molecule SDFs
- expose export button in UI and handle download in main script
- store SDF data on load and style new button
- test repository export logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fbc8cab088329ab8e31104e1a3710