### PR TITLE
feat: add molecule search filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,9 @@
                         </button>
                     </div>
                 </div>
+                <div class="molecule-controls">
+                    <input type="text" id="molecule-search" placeholder="Search molecules...">
+                </div>
                 <div id="molecule-grid" class="molecule-grid">
                     <div class="loading-indicator">Loading molecules...</div>
                 </div>

--- a/src/components/MoleculeCard.js
+++ b/src/components/MoleculeCard.js
@@ -251,6 +251,20 @@ class MoleculeCard {
         }
     }
 
+    filterMolecules(term) {
+        const search = term.trim().toLowerCase();
+        const cards = Array.from(this.grid.children).filter(c =>
+            (c.className || '').split(' ').includes('molecule-card')
+        );
+        cards.forEach(card => {
+            const code = card.dataset.moleculeCode?.toLowerCase() || '';
+            const name = card.dataset.moleculeName?.toLowerCase() || '';
+            const match = !search || code.includes(search) || name.includes(search);
+            if (!card.style) card.style = {};
+            card.style.display = match ? '' : 'none';
+        });
+    }
+
     clearAll() {
         const allCards = this.grid.querySelectorAll('.molecule-card');
         allCards.forEach(card => card.remove());

--- a/src/main.js
+++ b/src/main.js
@@ -55,6 +55,15 @@ class MoleculeManager {
             }
         });
 
+        const searchInput = document.getElementById('molecule-search');
+        if (searchInput) {
+            searchInput.addEventListener('input', e => {
+                if (this.cardUI) {
+                    this.cardUI.filterMolecules(e.target.value);
+                }
+            });
+        }
+
         // Tab switching for Molecules, Fragments, Proteins
         const tabButtons = document.querySelectorAll('.tab-button');
         const panels = [

--- a/tests/moleculeCard.test.js
+++ b/tests/moleculeCard.test.js
@@ -51,3 +51,31 @@ describe('MoleculeCard downloadSdf', () => {
     assert.strictEqual(URL.revokeObjectURL.mock.callCount(), 1);
   });
 });
+
+describe('MoleculeCard filterMolecules', () => {
+  it('shows matching cards and hides others', () => {
+    const grid = new Element('div');
+    const cardA = new Element('div');
+    cardA.className = 'molecule-card';
+    cardA.dataset.moleculeCode = 'ATP';
+    cardA.dataset.moleculeName = 'Adenosine';
+    cardA.style = {};
+    const cardB = new Element('div');
+    cardB.className = 'molecule-card';
+    cardB.dataset.moleculeCode = 'GTP';
+    cardB.dataset.moleculeName = 'Guanosine';
+    cardB.style = {};
+    grid.appendChild(cardA);
+    grid.appendChild(cardB);
+
+    const ui = new MoleculeCard(grid, {});
+
+    ui.filterMolecules('atp');
+    assert.strictEqual(cardA.style.display, '');
+    assert.strictEqual(cardB.style.display, 'none');
+
+    ui.filterMolecules('');
+    assert.strictEqual(cardA.style.display, '');
+    assert.strictEqual(cardB.style.display, '');
+  });
+});


### PR DESCRIPTION
## Summary
- add molecule search input and wire it to filter the molecule grid
- implement MoleculeCard.filterMolecules to hide non-matching cards
- test filtering behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fbc74380883299c9506e34db9918d