### PR TITLE
Add PR preview deployment workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -16,9 +16,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
       - run: npm ci
-      - run: npm run build
+      - run: npm run build -- --base=/molexplorer/pr-${{ github.event.pull_request.number }}/
       - name: Deploy preview
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
## Summary
- build and deploy PR previews to gh-pages
- comment preview URL and remove it on PR close

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_688fc449bc388329994ff491dfa517b6