### PR TITLE
refactor: fetch member details concurrently

### DIFF
--- a/src/components/ProteinBrowser.js
+++ b/src/components/ProteinBrowser.js
@@ -91,16 +91,13 @@ class ProteinBrowser {
     }
 
     async fetchMemberDetails(pdbIds) {
-        const details = [];
-        for (const pdbId of pdbIds) {
-            try {
-                const data = await ApiService.getRcsbEntry(pdbId);
-                details.push(data);
-            } catch (error) {
-                details.push({ rcsb_id: pdbId, error: 'Failed to fetch details' });
-            }
-        }
-        return details;
+        const detailPromises = pdbIds.map(pdbId =>
+            ApiService.getRcsbEntry(pdbId).catch(() => ({
+                rcsb_id: pdbId,
+                error: 'Failed to fetch details'
+            }))
+        );
+        return Promise.all(detailPromises);
     }
 
     async fetchBoundLigands(pdbId) {

--- a/tests/proteinBrowser.test.js
+++ b/tests/proteinBrowser.test.js
@@ -1,0 +1,51 @@
+import { describe, it, afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import ProteinBrowser from '../src/components/ProteinBrowser.js';
+import ApiService from '../src/utils/apiService.js';
+
+describe('ProteinBrowser.fetchMemberDetails', () => {
+  afterEach(() => {
+    mock.restoreAll();
+  });
+
+  it('fetches member details concurrently', async () => {
+    const ids = ['1ABC', '2DEF', '3GHI'];
+    let inFlight = 0;
+    let maxInFlight = 0;
+    mock.method(ApiService, 'getRcsbEntry', (pdbId) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      return new Promise((resolve) => {
+        setImmediate(() => {
+          inFlight--;
+          resolve({ rcsb_id: pdbId });
+        });
+      });
+    });
+
+    const browser = new ProteinBrowser(null);
+    const results = await browser.fetchMemberDetails(ids);
+
+    assert.strictEqual(maxInFlight, ids.length);
+    assert.deepStrictEqual(results.map(r => r.rcsb_id), ids);
+  });
+
+  it('returns error objects for failed fetches', async () => {
+    const ids = ['1ABC', '2DEF', '3GHI'];
+    mock.method(ApiService, 'getRcsbEntry', (pdbId) => {
+      if (pdbId === '2DEF') {
+        return Promise.reject(new Error('fail'));
+      }
+      return Promise.resolve({ rcsb_id: pdbId });
+    });
+
+    const browser = new ProteinBrowser(null);
+    const results = await browser.fetchMemberDetails(ids);
+
+    assert.deepStrictEqual(results, [
+      { rcsb_id: '1ABC' },
+      { rcsb_id: '2DEF', error: 'Failed to fetch details' },
+      { rcsb_id: '3GHI' }
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- refactor fetchMemberDetails to fetch entries concurrently via Promise.all
- return error objects when individual entry lookups fail
- add unit tests covering concurrent fetches and per-entry failures

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fc57309848329b523f341b7d058d2