### PR TITLE
Simplify MoleculeRepository clearing API

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -132,7 +132,7 @@ class MoleculeManager {
     }
 
     deleteAllMolecules() {
-        this.repository.clearAll();
+        this.repository.clear();
         if (this.cardUI) {
             this.cardUI.clearAll();
         }

--- a/src/utils/MoleculeRepository.js
+++ b/src/utils/MoleculeRepository.js
@@ -38,10 +38,6 @@ class MoleculeRepository {
         return true;
     }
 
-    deleteAllMolecules() {
-        this.molecules = [];
-    }
-
     getMolecule(identifier) {
         return this.molecules.find(
             m => m.id === identifier || m.code === identifier
@@ -59,7 +55,7 @@ class MoleculeRepository {
         return [...this.molecules];
     }
 
-    clearAll() {
+    clear() {
         this.molecules = [];
     }
 

--- a/tests/moleculeRepository.test.js
+++ b/tests/moleculeRepository.test.js
@@ -58,9 +58,9 @@ describe('MoleculeRepository', () => {
     assert.strictEqual(repo.getAllMolecules().length, 1);
   });
 
-  it('deleteAllMolecules clears repository', () => {
+  it('clear removes all molecules', () => {
     const repo = new MoleculeRepository([{ code: 'A', status: 'loaded' }]);
-    repo.deleteAllMolecules();
+    repo.clear();
     assert.strictEqual(repo.getAllMolecules().length, 0);
   });
 


### PR DESCRIPTION
## Summary
- drop redundant `deleteAllMolecules` from `MoleculeRepository`
- rename `clearAll()` to `clear()` and update `MoleculeManager` accordingly
- update repository tests for `clear()`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fc5af40848329a0f2b49e8c7846fd