### PR TITLE
Fix disclaimer modal blocking clicks

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -199,6 +199,15 @@ fragmentLibrary.loadFragments();
 
 const proteinBrowser = new ProteinBrowser(moleculeManager).init();
 
+// Handle launch disclaimer
+const disclaimerModal = document.getElementById('launch-disclaimer-modal');
+const acceptDisclaimerBtn = document.getElementById('accept-disclaimer-btn');
+if (disclaimerModal && acceptDisclaimerBtn) {
+    acceptDisclaimerBtn.addEventListener('click', () => {
+        disclaimerModal.style.display = 'none';
+    });
+}
+
 function showNotification(message, type = 'info') {
     const notification = document.createElement('div');
     notification.className = `notification ${type}`;


### PR DESCRIPTION
## Summary
- Ensure the launch disclaimer modal is dismissed when accepted

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fd5e81b7083298f7ef70d0d70756d