### PR TITLE
fix: allow molecule card viewer interactions

### DIFF
--- a/src/components/MoleculeCard.js
+++ b/src/components/MoleculeCard.js
@@ -12,7 +12,7 @@ class MoleculeCard {
     createMoleculeCardFromSmiles(smiles, ccdCode, id = ccdCode) {
         const card = document.createElement('div');
         card.className = 'molecule-card';
-        card.draggable = true;
+        card.draggable = false;
         card.setAttribute('data-molecule-code', ccdCode);
         card.setAttribute('data-molecule-id', id);
 
@@ -20,6 +20,14 @@ class MoleculeCard {
         dragHandle.className = 'drag-handle';
         dragHandle.innerHTML = '⋯';
         card.appendChild(dragHandle);
+        dragHandle.addEventListener('mousedown', () => {
+            card.draggable = true;
+        });
+        ['mouseup', 'mouseleave'].forEach(evt => {
+            dragHandle.addEventListener(evt, () => {
+                card.draggable = false;
+            });
+        });
 
         const deleteBtn = document.createElement('div');
         deleteBtn.className = 'delete-btn';
@@ -78,7 +86,7 @@ class MoleculeCard {
     createMoleculeCard(data, ccdCode, format = 'sdf', id = ccdCode) {
         const card = document.createElement('div');
         card.className = 'molecule-card';
-        card.draggable = true;
+        card.draggable = false;
         card.setAttribute('data-molecule-code', ccdCode);
         card.setAttribute('data-molecule-id', id);
 
@@ -86,6 +94,14 @@ class MoleculeCard {
         dragHandle.className = 'drag-handle';
         dragHandle.innerHTML = '⋯';
         card.appendChild(dragHandle);
+        dragHandle.addEventListener('mousedown', () => {
+            card.draggable = true;
+        });
+        ['mouseup', 'mouseleave'].forEach(evt => {
+            dragHandle.addEventListener(evt, () => {
+                card.draggable = false;
+            });
+        });
 
         const deleteBtn = document.createElement('div');
         deleteBtn.className = 'delete-btn';
@@ -141,7 +157,7 @@ class MoleculeCard {
     createNotFoundCard(ccdCode, message = 'Not found', id = ccdCode) {
         const card = document.createElement('div');
         card.className = 'molecule-card';
-        card.draggable = true;
+        card.draggable = false;
         card.setAttribute('data-molecule-code', ccdCode);
         card.setAttribute('data-molecule-id', id);
 
@@ -149,6 +165,14 @@ class MoleculeCard {
         dragHandle.className = 'drag-handle';
         dragHandle.innerHTML = '⋯';
         card.appendChild(dragHandle);
+        dragHandle.addEventListener('mousedown', () => {
+            card.draggable = true;
+        });
+        ['mouseup', 'mouseleave'].forEach(evt => {
+            dragHandle.addEventListener(evt, () => {
+                card.draggable = false;
+            });
+        });
 
         const deleteBtn = document.createElement('div');
         deleteBtn.className = 'delete-btn';


### PR DESCRIPTION
## Summary
- restrict molecule card dragging to drag handle
- allow 3D viewer to receive click/drag events

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fd5e81b7083298f7ef70d0d70756d