### PR TITLE
feat: configure Vite base path via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,21 @@ Run the test suite:
 npm test
 ```
 
+## Deployment
+The application assumes it is served from `/molexplorer/` by default. To deploy under a
+different repository name or a custom domain, set the `BASE_PATH` environment variable
+to the path where the site will be hosted and rebuild:
+
+```
+BASE_PATH=/my-other-repo/ npm run build
+```
+
+For a custom domain served from the root, use `/`:
+
+```
+BASE_PATH=/ npm run build
+```
+
 ## API References
 - [PDBe Graph API](https://www.ebi.ac.uk/pdbe/graph-api/pdbe_doc/)
 - [RCSB PDB REST API](https://data.rcsb.org/redoc/index.html)

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,10 @@
 import { defineConfig } from 'vite';
 
 // https://vitejs.dev/config/
+const base = process.env.BASE_PATH || '/molexplorer/';
+
 export default defineConfig({
-    base: '/molexplorer/',
+    base,
     server: {
         proxy: {
             '/rcsb': {
@@ -12,7 +14,7 @@ export default defineConfig({
             },
         },
         fs: {
-            allow: ['..']
-        }
+            allow: ['..'],
+        },
     },
-}); 
+});


### PR DESCRIPTION
## Summary
- compute Vite `base` from `BASE_PATH` env var with default `/molexplorer/`
- document setting `BASE_PATH` for custom deployments

## Testing
- `npm test`
- `BASE_PATH=/newrepo/ npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fd88fe7708329a7dac7bfc736f100