### PR TITLE
feat: add molecular property panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,6 +277,11 @@
                 </div>
 
                 <div class="details-section">
+                    <h4>Molecular Properties</h4>
+                    <div id="ligand-properties" class="properties-panel">Loading properties...</div>
+                </div>
+
+                <div class="details-section">
                     <h4>PDB Entries</h4>
                     <div id="pdb-entries-container">
                         <p>Loading PDB entries...</p>

--- a/src/modal/LigandModal.js
+++ b/src/modal/LigandModal.js
@@ -1,18 +1,40 @@
 import LigandDetails from './LigandDetails.js';
 import SimilarLigandTable from './SimilarLigandTable.js';
 import PdbEntryList from './PdbEntryList.js';
+import PropertyCalculator from '../utils/propertyCalculator.js';
 
 class LigandModal {
     constructor(moleculeManager) {
         this.details = new LigandDetails(moleculeManager);
         this.similarLigandTable = new SimilarLigandTable(moleculeManager);
         this.pdbEntryList = new PdbEntryList(moleculeManager);
+        this.propertiesContainer = document.getElementById('ligand-properties');
     }
 
     show(ccdCode, sdfData) {
         this.details.show(ccdCode, sdfData);
         this.similarLigandTable.load(ccdCode);
         this.pdbEntryList.load(ccdCode);
+
+        if (this.propertiesContainer) {
+            this.propertiesContainer.textContent = 'Loading properties...';
+            PropertyCalculator.getProperties(ccdCode)
+                .then(props => {
+                    if (props) {
+                        const mw = props.molecularWeight ?? 'N/A';
+                        const formula = props.formula ?? 'N/A';
+                        this.propertiesContainer.innerHTML = `
+                            <div>Molecular Weight: ${mw}</div>
+                            <div>Formula: ${formula}</div>
+                        `;
+                    } else {
+                        this.propertiesContainer.textContent = 'Properties unavailable';
+                    }
+                })
+                .catch(() => {
+                    this.propertiesContainer.textContent = 'Properties unavailable';
+                });
+        }
     }
 
     close() {

--- a/src/utils/propertyCalculator.js
+++ b/src/utils/propertyCalculator.js
@@ -1,0 +1,38 @@
+/**
+ * PropertyCalculator - fetches molecular properties from public APIs.
+ *
+ * Currently uses the RCSB PDB chemical component service to retrieve
+ * molecular formula and molecular weight for a given CCD code.
+ *
+ * @see https://data.rcsb.org/redoc/index.html#tag/chemcomp
+ */
+
+const BASE_URL = 'https://data.rcsb.org/rest/v1/core/chemcomp';
+
+export default class PropertyCalculator {
+  /**
+   * Fetch molecular properties for a chemical component.
+   *
+   * @param {string} ccdCode - Three-letter chemical component code.
+   * @returns {Promise<{molecularWeight: number|null, formula: string|null}|null>}
+   *   Object with properties or null if unavailable.
+   */
+  static async getProperties(ccdCode) {
+    try {
+      const response = await fetch(`${BASE_URL}/${ccdCode.toUpperCase()}`);
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+      const data = await response.json();
+      const comp = data?.chem_comp || {};
+      return {
+        molecularWeight: comp.formula_weight ?? null,
+        formula: comp.formula ?? null,
+      };
+    } catch (e) {
+      console.error(`Failed to fetch properties for ${ccdCode}:`, e);
+      return null;
+    }
+  }
+}
+

--- a/tests/ligandModal.test.js
+++ b/tests/ligandModal.test.js
@@ -4,12 +4,14 @@ import LigandModal from '../src/modal/LigandModal.js';
 import LigandDetails from '../src/modal/LigandDetails.js';
 import SimilarLigandTable from '../src/modal/SimilarLigandTable.js';
 import PdbEntryList from '../src/modal/PdbEntryList.js';
+import PropertyCalculator from '../src/utils/propertyCalculator.js';
 
 describe('LigandModal orchestrator', () => {
   it('delegates to subcomponents', () => {
     const makeEl = () => ({ style: {}, addEventListener: () => {}, innerHTML: '', textContent: '' });
+    const propsEl = makeEl();
     global.document = {
-      getElementById: makeEl,
+      getElementById: (id) => (id === 'ligand-properties' ? propsEl : makeEl()),
       querySelectorAll: () => [makeEl(), makeEl()]
     };
     global.window = { addEventListener: () => {} };
@@ -18,6 +20,7 @@ describe('LigandModal orchestrator', () => {
     const loadSimilarSpy = mock.method(SimilarLigandTable.prototype, 'load', () => {});
     const load2DSpy = mock.method(SimilarLigandTable.prototype, 'load2DStructure', () => {});
     const loadPdbSpy = mock.method(PdbEntryList.prototype, 'load', () => {});
+    mock.method(PropertyCalculator, 'getProperties', async () => null);
 
     const lm = new LigandModal({});
     lm.show('ATP', 'sdf');
@@ -31,6 +34,61 @@ describe('LigandModal orchestrator', () => {
     assert.deepStrictEqual(loadPdbSpy.mock.calls[0].arguments, ['ATP']);
     assert.strictEqual(load2DSpy.mock.callCount(), 1);
     assert.deepStrictEqual(load2DSpy.mock.calls[0].arguments, ['ATP', 'container']);
+
+    mock.restoreAll();
+    delete global.document;
+    delete global.window;
+  });
+});
+
+describe('LigandModal properties panel', () => {
+  const makeEl = () => ({ style: {}, addEventListener: () => {}, innerHTML: '', textContent: '' });
+
+  it('displays fetched properties', async () => {
+    const propsEl = makeEl();
+    global.document = {
+      getElementById: (id) => (id === 'ligand-properties' ? propsEl : makeEl()),
+      querySelectorAll: () => [makeEl(), makeEl()]
+    };
+    global.window = { addEventListener: () => {} };
+
+    mock.method(LigandDetails.prototype, 'show', () => {});
+    mock.method(SimilarLigandTable.prototype, 'load', () => {});
+    mock.method(PdbEntryList.prototype, 'load', () => {});
+    mock.method(PropertyCalculator, 'getProperties', async () => ({ molecularWeight: 55, formula: 'C2H6O' }));
+
+    const lm = new LigandModal({});
+    lm.show('ETH', 'sdf');
+
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.ok(propsEl.innerHTML.includes('55'));
+    assert.ok(propsEl.innerHTML.includes('C2H6O'));
+
+    mock.restoreAll();
+    delete global.document;
+    delete global.window;
+  });
+
+  it('shows fallback when properties unavailable', async () => {
+    const propsEl = makeEl();
+    global.document = {
+      getElementById: (id) => (id === 'ligand-properties' ? propsEl : makeEl()),
+      querySelectorAll: () => [makeEl(), makeEl()]
+    };
+    global.window = { addEventListener: () => {} };
+
+    mock.method(LigandDetails.prototype, 'show', () => {});
+    mock.method(SimilarLigandTable.prototype, 'load', () => {});
+    mock.method(PdbEntryList.prototype, 'load', () => {});
+    mock.method(PropertyCalculator, 'getProperties', async () => { throw new Error('fail'); });
+
+    const lm = new LigandModal({});
+    lm.show('BAD', 'sdf');
+
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.strictEqual(propsEl.textContent, 'Properties unavailable');
 
     mock.restoreAll();
     delete global.document;


### PR DESCRIPTION
## Summary
- add propertyCalculator utility to fetch molecular formula and weight
- render molecular properties in LigandModal with graceful fallbacks
- add molecular property tests for LigandModal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fe048de608329a2cdc5a285195c7b