### PR TITLE
refactor: make ApiService injectable

### DIFF
--- a/docs/refactor-plan.md
+++ b/docs/refactor-plan.md
@@ -1,0 +1,28 @@
+# Refactor Plan: Modern Component Framework and TypeScript
+
+This document outlines a proposal to restructure the Molexplorer codebase for improved maintainability and scalability.
+
+## Component Framework and Centralized State
+- Replace the current monolithic initialization logic with a modern component framework such as **React** or **Vue**.
+- Introduce a centralized store (e.g., **Redux**, **Vuex**, or **Pinia**) so components like the molecule grid, fragment library, and protein browser share a single source of truth.
+- Each view should become its own component, enabling isolated development and testing.
+
+## Declarative Components
+- Refactor manual DOM construction (e.g., `MoleculeCard`) into declarative components.
+- Leverage JSX or Vue single-file components to reduce boilerplate, encourage reuse, and simplify event handling.
+
+## Service Layer and Dependency Injection
+- Convert `ApiService` from static methods and a global cache into an injectable class with a clear interface.
+- Dependency injection makes it easier to mock services during testing and to add cross-cutting concerns like retries or logging.
+
+## TypeScript Adoption
+- Introduce TypeScript across the codebase.
+- Define interfaces for entities such as `Molecule` and `PdbEntry` to enable static type checking.
+- Use typed props and generics in components to improve clarity of contracts and API responses.
+
+## Expected Benefits
+- Clear separation of concerns and easier onboarding for new contributors.
+- Improved maintainability and extensibility as new UI features or API endpoints are added.
+- Better testability through isolated components and injected services.
+- Greater developer productivity and reliability thanks to strong typing and reusable components.
+

--- a/src/components/BoundLigandTable.js
+++ b/src/components/BoundLigandTable.js
@@ -1,8 +1,8 @@
-import ApiService from '../utils/apiService.js';
 import { EXCLUDED_LIGANDS, ADD_LIGAND_DELAY_MS } from '../utils/constants.js';
 
 class BoundLigandTable {
-    constructor(addMolecule, showMoleculeDetails, ligandModal) {
+    constructor(apiService, addMolecule, showMoleculeDetails, ligandModal) {
+        this.apiService = apiService;
         this.addMolecule = addMolecule;
         this.showMoleculeDetails = showMoleculeDetails;
         this.ligandModal = ligandModal;
@@ -17,7 +17,7 @@ class BoundLigandTable {
 
         tableBody.innerHTML = '';
 
-        ApiService.getLigandMonomers(pdbId)
+        this.apiService.getLigandMonomers(pdbId)
             .then(data => {
                 const ligands = data[pdbId.toLowerCase()];
 

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@ import MoleculeLoader from './utils/MoleculeLoader.js';
 import MoleculeRepository from './utils/MoleculeRepository.js';
 import { DEFAULT_MOLECULE_CODES } from './utils/constants.js';
 import BoundLigandTable from './components/BoundLigandTable.js';
+import apiService from './utils/apiService.js';
 import FragmentLibrary from './components/FragmentLibrary.js';
 import LigandModal from './modal/LigandModal.js';
 import MoleculeCard from './components/MoleculeCard.js';
@@ -36,6 +37,7 @@ class MoleculeManager {
         this.loader = new MoleculeLoader(this.repository, this.cardUI);
         this.ligandModal = new LigandModal(this);
         this.boundLigandTable = new BoundLigandTable(
+            apiService,
             molecule => this.addMolecule(molecule),
             code => this.showMoleculeDetails(code),
             this.ligandModal

--- a/src/utils/apiService.js
+++ b/src/utils/apiService.js
@@ -1,12 +1,11 @@
 /**
  * ApiService - Centralized service for all external API calls
  *
- * This service handles communication with various molecular biology databases:
- * - RCSB PDB (Protein Data Bank) - Primary protein structure database
- * - PDBe (Protein Data Bank in Europe) - European protein structure database
- * - Local data files (TSV) - Fragment libraries
- *
- * @see https://www.ebi.ac.uk/pdbe/graph-api/pdbe_doc/ for PDBe API documentation
+ * Provides methods for retrieving data from several molecular biology
+ * databases. The service is designed as an injectable class so that different
+ * fetch implementations (real network, mocked, etc.) can be supplied when
+ * constructing an instance. A default singleton instance is exported for
+ * convenience and maintains an internal response cache.
  */
 
 import {
@@ -22,299 +21,146 @@ import {
   RCSB_GROUP_BASE_URL
 } from './constants.js';
 
-// In-memory cache for URL -> parsed response pairs
-const responseCache = new Map();
-
-export default class ApiService {
+/**
+ * Injectable API service.
+ */
+class ApiService {
   /**
-   * Perform a fetch request and parse the response using the provided parser.
-   *
-   * @param {string} url - Target URL.
-   * @param {(response: Response) => Promise<any>} parser - Function that parses the response.
-   * @returns {Promise<any>} Parsed response data.
+   * @param {Function} fetchFn - Fetch implementation (defaults to global fetch)
+   */
+  constructor(fetchFn = (...args) => fetch(...args)) {
+    this.fetch = fetchFn;
+    this.responseCache = new Map();
+  }
+
+  /**
+   * Internal fetch helper with caching.
+   * @param {string} url
+   * @param {(resp: Response) => Promise<any>} parser
+   * @returns {Promise<any>}
    * @private
    */
-  static async #fetchResource(url, parser) {
-    if (responseCache.has(url)) {
-      return responseCache.get(url);
+  async #fetchResource(url, parser) {
+    if (this.responseCache.has(url)) {
+      return this.responseCache.get(url);
     }
 
-    const response = await fetch(url);
+    const response = await this.fetch(url);
     if (!response.ok) {
       const error = new Error(`HTTP error! status: ${response.status}`);
       error.status = response.status;
       error.url = url;
       throw error;
     }
+
     const parsed = await parser(response);
-    responseCache.set(url, parsed);
+    this.responseCache.set(url, parsed);
     return parsed;
   }
 
   /**
    * Fetch a plain text resource.
-   *
-   * @param {string} url - Target URL.
-   * @returns {Promise<string>} Response body as text.
-   * @example
-   * const txt = await ApiService.fetchText('/example.txt');
-   * // txt => 'file contents'
+   * @param {string} url
+   * @returns {Promise<string>}
    */
-  static async fetchText(url) {
+  fetchText(url) {
     return this.#fetchResource(url, (response) => response.text());
   }
 
   /**
    * Fetch a JSON resource.
-   *
-   * @param {string} url - Target URL.
-   * @returns {Promise<Object>} Parsed JSON response.
-   * @example
-   * const data = await ApiService.fetchJson('https://example.com/data.json');
-   * // data => { "id": 1 }
+   * @param {string} url
+   * @returns {Promise<any>}
    */
-  static async fetchJson(url) {
+  fetchJson(url) {
     return this.#fetchResource(url, (response) => response.json());
   }
 
   /**
-   * Fetch ideal chemical component data from PDBe Graph API
-   *
-   * Retrieves the ideal (reference) structure for a chemical component from the 
-   * Chemical Component Dictionary (CCD) via PDBe's Graph API.
-   *
-   * @param {string} ligandCode - The 3-letter CCD code (e.g., 'ATP', 'HEM')
-   * @returns {Promise<string>} SDF file content as string
-   *
-   * @example
-   * // Example SDF response for ligandCode 'HEM':
-   * const sdf = await ApiService.getCcdSdf('HEM');
-   * // sdf.startsWith('HEM') => true
-   *
-   * @note
-   * - Uses PDBe Graph API endpoint: /api/pdb/entry/ideal_ccd/{ligandCode}
-   * - Returns ideal (reference) structure, not experimental data
-   * - Chemical components are standardized molecular entities in the CCD
-   *
-   * @see https://www.ebi.ac.uk/pdbe/graph-api/pdbe_doc/ for API documentation
+   * Fetch ideal chemical component data from PDBe Graph API.
+   * @param {string} ccdCode
+   * @returns {Promise<string>}
    */
-  static getCcdSdf(ccdCode) {
-    return this.fetchText(
-      `${RCSB_LIGAND_BASE_URL}/${ccdCode.toUpperCase()}_ideal.sdf`
-    );
+  getCcdSdf(ccdCode) {
+    return this.fetchText(`${RCSB_LIGAND_BASE_URL}/${ccdCode.toUpperCase()}_ideal.sdf`);
   }
 
   /**
-   * Fetch experimental ligand instance data from RCSB models API
-   *
-   * Retrieves the experimentally observed coordinates for a specific ligand
-   * instance within a PDB entry.
-   *
-   * @param {string} pdbId - The 4-character PDB ID
-   * @param {string|number} authSeqId - Author provided residue/sequence number
-   * @param {string} labelAsymId - Chain identifier
-   * @returns {Promise<string>} SDF file content for the ligand instance
+   * Fetch experimental ligand instance data from RCSB models API.
    */
-  static getInstanceSdf(pdbId, authSeqId, labelAsymId) {
+  getInstanceSdf(pdbId, authSeqId, labelAsymId) {
     return this.fetchText(
       `${RCSB_MODEL_BASE_URL}/${pdbId.toUpperCase()}/ligand?auth_seq_id=${authSeqId}&label_asym_id=${labelAsymId}&encoding=sdf`
     );
   }
+
   /**
-   * Fetch fragment library data from local TSV file
-   *
-   * Loads fragment library data containing molecular fragments with their
-   * properties, sources, and structural information.
-   *
-   * @returns {Promise<string>} TSV file contents as string
-   *
-   * @example
-   * // Example TSV first line:
-   * // fragment_id\tsmiles\tsource\tdescription\t...
-   *
-   * @note
-   * - TSV format with tab-separated values
-   * - Contains fragments from multiple sources (PDBe, ENAMINE, DSI)
-   * - Used for fragment-based drug discovery workflows
+   * Fetch fragment library data from local TSV file.
    */
-  static getFragmentLibraryTsv() {
-    // Fetch fragment library TSV from GitHub
+  getFragmentLibraryTsv() {
     return this.fetchText(FRAGMENT_LIBRARY_URL);
   }
 
   /**
-   * Fetch similar ligands for a given chemical component
-   *
-   * Retrieves structurally similar ligands from PDBe's similarity search API.
-   * Returns ligands that share structural features with the query molecule.
-   *
-   * @param {string} ligandCode - The 3-letter CCD code to find similar ligands for
-   * @returns {Promise<Object>} Mapping of the CCD code to an array of similar components
-   *
-   * @example
-   * await ApiService.getSimilarCcds('ATP');
-   * // => { "ATP": [ { "ccd_id": "ADP", "similarity": 0.75 } ] }
-   *
-   * @note
-   * - Uses PDBe similarity search algorithms
-   * - Similarity types: scaffold, stereoisomer, similar
-   * - Scores range from 0.0 to 1.0 (higher = more similar)
-   *
-   * @see https://www.ebi.ac.uk/pdbe/graph-api/pdbe_doc/ for similarity search API
+   * Fetch similar ligands for a given chemical component.
    */
-  static getSimilarCcds(ccdCode) {
+  getSimilarCcds(ccdCode) {
     return this.fetchJson(`${PD_BE_SIMILARITY_BASE_URL}/${ccdCode}`);
   }
 
   /**
-   * Fetch PDB entries containing a specific ligand
-   *
-   * Retrieves all PDB entries where the specified chemical component appears
-   * as a bound ligand in protein structures.
-   *
-   * @param {string} ligandCode - The 3-letter CCD code to search for
-   * @returns {Promise<Object>} Mapping of the CCD code to an array of PDB IDs
-   *
-   * @example
-   * await ApiService.getPdbEntriesForCcd('ATP');
-   * // => { "ATP": ["2MZ5", "3AMO"] }
-   *
-   * @note
-   * - Searches across all PDB entries for ligand binding
-   * - Returns experimental protein-ligand complexes
-   * - Includes structural and experimental metadata
-   *
-   * @see https://www.ebi.ac.uk/pdbe/graph-api/pdbe_doc/ for PDB search API
+   * Fetch PDB entries containing a specific ligand.
    */
-  static getPdbEntriesForCcd(ccdCode) {
+  getPdbEntriesForCcd(ccdCode) {
     return this.fetchJson(`${PD_BE_IN_PDB_BASE_URL}/${ccdCode}`);
   }
 
   /**
-   * Fetch detailed PDB entry information from RCSB API
-   *
-   * Retrieves comprehensive information about a specific PDB entry including
-   * structural metadata, experimental details, and publication information.
-   *
-   * @param {string} pdbId - The 4-character PDB ID (e.g., '1ATP', '4HHB')
-   * @returns {Promise<Object|null>} PDB entry details or null if failed
-   *
-   * @example
-   * const entry = await ApiService.getRcsbEntry('1CBS');
-   * // entry.rcsb_id => '1CBS'
-   *
-   * @note
-   * - Uses RCSB PDB REST API
-   * - Returns comprehensive structural and experimental metadata
-   * - Includes entity information for proteins, nucleic acids, and ligands
-   *
-   * @see https://data.rcsb.org/redoc/index.html for RCSB API documentation
+   * Fetch detailed PDB entry information from RCSB API.
    */
-  static getRcsbEntry(pdbId) {
+  getRcsbEntry(pdbId) {
     return this.fetchJson(`${RCSB_ENTRY_BASE_URL}/${pdbId.toLowerCase()}`);
   }
 
   /**
-   * Fetch PDBe summary information for a PDB entry
-   *
-   * Retrieves summary information about a PDB entry from PDBe's Graph API,
-   * including structural statistics, experimental details, and quality metrics.
-   *
-   * @param {string} pdbId - The 4-character PDB ID (e.g., '1ATP', '4HHB')
-   * @returns {Promise<Object|null>} PDBe summary data or null if failed
-   *
-   * @example
-   * const summary = await ApiService.getPdbSummary('1CBS');
-   * // summary['1cbs'][0].title => 'CRYSTAL STRUCTURE OF ADENOSINE KINASE'
-   *
-   * @note
-   * - Uses PDBe Graph API for comprehensive structural information
-   * - Includes quality indicators and experimental metadata
-   * - Provides entity-level information for all molecular components
-   *
-   * @see https://www.ebi.ac.uk/pdbe/graph-api/pdbe_doc/ for PDBe API documentation
+   * Fetch PDBe summary information for a PDB entry.
    */
-  static getPdbSummary(pdbId) {
+  getPdbSummary(pdbId) {
     return this.fetchJson(`${PD_BE_SUMMARY_BASE_URL}/${pdbId}`);
   }
 
   /**
-   * Fetch PDB file in mmCIF format from RCSB
-   *
-   * Downloads the complete PDB file containing atomic coordinates and
-   * structural information in mmCIF format for 3D visualization.
-   *
-   * @param {string} pdbId - The 4-character PDB ID (e.g., '1ATP', '4HHB')
-   * @returns {Promise<string>} PDB file content in mmCIF format
-   *
-   * @example
-   * const pdb = await ApiService.getPdbFile('1CBS');
-   * // pdb.startsWith('HEADER') => true
-   *
-   * @note
-   * - mmCIF format is the standard for PDB structural data
-   * - Contains atomic coordinates, B-factors, and structural metadata
-   * - Used for 3D molecular visualization with 3Dmol.js
-   *
-   * @see https://www.wwpdb.org/data/file-format for mmCIF format specification
+   * Fetch PDB file in mmCIF format from RCSB.
    */
-  static getPdbFile(pdbId) {
+  getPdbFile(pdbId) {
     return this.fetchText(`${RCSB_PDB_DOWNLOAD_BASE_URL}/${pdbId}.pdb`);
   }
 
   /**
-   * Fetch bound ligands for a specific PDB entry
-   *
-   * Retrieves all chemical components bound to the protein structure,
-   * including their binding sites, chain information, and structural details.
-   *
-   * @param {string} pdbId - The 4-character PDB ID (e.g., '1ATP', '4HHB')
-   * @returns {Promise<Object>} Ligand monomer data keyed by PDB ID
-   *
-   * @example
-   * await ApiService.getLigandMonomers('1CBS');
-   * // => { "1cbs": [ { "chem_comp_id": "ATP", ... } ] }
-   *
-   * @note
-   * - Includes both small molecules and ions
-   * - Provides binding site and structural information
-   * - Used for analyzing protein-ligand interactions
-   *
-   * @see https://www.ebi.ac.uk/pdbe/graph-api/pdbe_doc/ for bound ligands API
+   * Fetch bound ligands for a specific PDB entry.
    */
-  static getLigandMonomers(pdbId) {
+  getLigandMonomers(pdbId) {
     return this.fetchJson(`${PD_BE_LIGAND_MONOMERS_BASE_URL}/${pdbId}`);
   }
 
   /**
-   * Fetch protein group information from RCSB API
-   *
-   * Retrieves information about protein groups, which are collections of
-   * related PDB entries (e.g., same protein with different ligands).
-   *
-   * @param {string} groupId - The protein group ID (e.g., 'G_1002155')
-   * @returns {Promise<Object|null>} Protein group data or null if failed
-   *
-   * @example
-   * const group = await ApiService.getProteinGroup('P12345');
-   * // group.group_id => 'P12345'
-   *
-   * @note
-   * - PDB IDs are in rcsb_group_container_identifiers.group_member_ids array
-   * - Group metadata is in rcsb_group_info object
-   * - This is NOT the same structure as individual PDB entry APIs
-   *
-   * @see https://data.rcsb.org/redoc/index.html for RCSB group API documentation
+   * Fetch protein group information from RCSB API.
    */
-  static getProteinGroup(groupId) {
+  getProteinGroup(groupId) {
     return this.fetchJson(`${RCSB_GROUP_BASE_URL}/${groupId}`);
   }
 
   /**
    * Clear the internal response cache.
-   * Useful for tests or debugging to force re-fetching resources.
    */
-  static clearCache() {
-    responseCache.clear();
+  clearCache() {
+    this.responseCache.clear();
   }
 }
+
+// Default singleton instance
+const apiService = new ApiService();
+
+export { ApiService };
+export default apiService;
+

--- a/tests/boundLigandTable.test.js
+++ b/tests/boundLigandTable.test.js
@@ -2,11 +2,12 @@ import { describe, it, beforeEach, afterEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { JSDOM, Element } from './domStub.js';
 import BoundLigandTable from '../src/components/BoundLigandTable.js';
-import ApiService from '../src/utils/apiService.js';
+import { ApiService } from '../src/utils/apiService.js';
 
 let dom;
 let table;
 let addMoleculeStub;
+let api;
 
 const setupDom = () => {
   dom = new JSDOM();
@@ -41,7 +42,8 @@ const setupDom = () => {
 beforeEach(() => {
   setupDom();
   addMoleculeStub = mock.fn(() => true);
-  table = new BoundLigandTable(addMoleculeStub, () => {}, null);
+  api = new ApiService();
+  table = new BoundLigandTable(api, addMoleculeStub, () => {}, null);
 });
 
 afterEach(() => {
@@ -55,7 +57,7 @@ describe('populateBoundLigands', () => {
       { chem_comp_id: 'AAA', chain_id: 'A', author_residue_number: '1', entity_id: '1', chem_comp_name: 'LigA' },
       { chem_comp_id: 'HOH', chain_id: 'B', author_residue_number: '2', entity_id: '2', chem_comp_name: 'Water' }
     ];
-    mock.method(ApiService, 'getLigandMonomers', async () => ({ '1abc': ligands }));
+    mock.method(api, 'getLigandMonomers', async () => ({ '1abc': ligands }));
     const addAllSpy = mock.method(table, 'addAllLigands', () => {});
 
     table.populateBoundLigands('1ABC');
@@ -79,7 +81,7 @@ describe('populateBoundLigands', () => {
   });
 
   it('shows message when no ligands found', async () => {
-    mock.method(ApiService, 'getLigandMonomers', async () => ({ '1abc': [] }));
+    mock.method(api, 'getLigandMonomers', async () => ({ '1abc': [] }));
 
     table.populateBoundLigands('1ABC');
     await new Promise(r => setImmediate(r));
@@ -96,7 +98,7 @@ describe('populateBoundLigands', () => {
   });
 
   it('handles API errors gracefully', async () => {
-    mock.method(ApiService, 'getLigandMonomers', async () => { throw new Error('fail'); });
+    mock.method(api, 'getLigandMonomers', async () => { throw new Error('fail'); });
 
     table.populateBoundLigands('1ABC');
     await new Promise(r => setImmediate(r));


### PR DESCRIPTION
## Summary
- convert ApiService from static methods to an injectable class with a default singleton
- inject ApiService into BoundLigandTable via MoleculeManager
- document plan to migrate to a modern component framework with centralized state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fe0d1880c8329a8d2b7604de8d4e6