### PR TITLE
fix: use relative base path for Vite

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-    base: '/molexplorer/',
+    base: './',
     server: {
         proxy: {
             '/rcsb': {


### PR DESCRIPTION
## Summary
- use a relative base path so preview builds load assets correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fe4dfdfa08329bc784037fe9fb2cb