### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
         <h1>ChemLogic Interface</h1>
         <p>Molecular Data Visualization and Pattern Analysis</p>
         <p class="author">By Charlie Harris 🛡️</p>
+        <button id="theme-toggle" class="theme-toggle-btn">Dark Mode</button>
     </header>
     <main>
         <div class="tabs">

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ import MoleculeCard from './components/MoleculeCard.js';
 import PdbDetailsModal from './modal/PdbDetailsModal.js';
 import AddMoleculeModal from './modal/AddMoleculeModal.js';
 import ProteinBrowser from './components/ProteinBrowser.js';
+import initThemeToggle from './utils/themeToggle.js';
 
 class MoleculeManager {
     constructor() {
@@ -198,6 +199,7 @@ const fragmentLibrary = new FragmentLibrary(moleculeManager, {
 fragmentLibrary.loadFragments();
 
 const proteinBrowser = new ProteinBrowser(moleculeManager).init();
+initThemeToggle();
 
 function showNotification(message, type = 'info') {
     const notification = document.createElement('div');

--- a/src/utils/themeToggle.js
+++ b/src/utils/themeToggle.js
@@ -1,0 +1,27 @@
+export function toggleDarkMode(doc = document) {
+    const body = doc.body;
+    const toggleBtn = doc.getElementById('theme-toggle');
+    if (!body || !toggleBtn) return;
+    let isDark;
+    if (body.classList && typeof body.classList.toggle === 'function') {
+        isDark = body.classList.toggle('dark-mode');
+    } else {
+        const classes = body.className.split(' ').filter(Boolean);
+        const idx = classes.indexOf('dark-mode');
+        if (idx >= 0) {
+            classes.splice(idx, 1);
+            isDark = false;
+        } else {
+            classes.push('dark-mode');
+            isDark = true;
+        }
+        body.className = classes.join(' ');
+    }
+    toggleBtn.textContent = isDark ? 'Light Mode' : 'Dark Mode';
+}
+
+export default function initThemeToggle(doc = document) {
+    const toggleBtn = doc.getElementById('theme-toggle');
+    if (!toggleBtn) return;
+    toggleBtn.addEventListener('click', () => toggleDarkMode(doc));
+}

--- a/style.css
+++ b/style.css
@@ -26,12 +26,40 @@ header p {
 header .author {
     position: absolute;
     top: 15px;
-    right: 20px;
+    right: 110px;
     margin: 0;
     font-size: 12px;
     font-weight: 400;
     opacity: 0.8;
     font-style: italic;
+}
+
+header .theme-toggle-btn {
+    position: absolute;
+    top: 15px;
+    right: 20px;
+    padding: 6px 12px;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    background: #ffffff;
+    color: #333;
+    font-size: 12px;
+}
+
+body.dark-mode {
+    background-color: #1e1e1e;
+    color: #f5f5f5;
+}
+
+body.dark-mode header {
+    background: linear-gradient(90deg, #333 0%, #555 100%);
+    color: #f5f5f5;
+}
+
+body.dark-mode header .theme-toggle-btn {
+    background: #333;
+    color: #f5f5f5;
 }
 
 main {

--- a/tests/themeToggle.test.js
+++ b/tests/themeToggle.test.js
@@ -1,0 +1,26 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM, Element } from './domStub.js';
+import { toggleDarkMode } from '../src/utils/themeToggle.js';
+
+describe('toggleDarkMode', () => {
+  it('toggles dark-mode class on body and updates button text', () => {
+    const dom = new JSDOM();
+    const { document } = dom.window;
+    document.body = new Element('body');
+    document.body.className = '';
+    const btn = new Element('button');
+    btn.id = 'theme-toggle';
+    btn.textContent = 'Dark Mode';
+    document.registerElement('theme-toggle', btn);
+    document.body.appendChild(btn);
+
+    toggleDarkMode(document);
+    assert.equal(document.body.className, 'dark-mode');
+    assert.equal(btn.textContent, 'Light Mode');
+
+    toggleDarkMode(document);
+    assert.equal(document.body.className, '');
+    assert.equal(btn.textContent, 'Dark Mode');
+  });
+});


### PR DESCRIPTION
## Summary
- add dark mode toggle button to header and style
- add theme toggle utility and tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fea84cf80832999c8b89df9cb7c37