### PR TITLE
feat: add tag management

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,6 +227,24 @@
         </div>
     </div>
 
+    <!-- Tag Modal -->
+    <div id="tag-modal" class="modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3>Add Tag</h3>
+                <span class="close" id="tag-close-modal">&times;</span>
+            </div>
+            <div class="modal-body">
+                <label for="tag-input">Tag or note:</label>
+                <input type="text" id="tag-input">
+            </div>
+            <div class="modal-footer">
+                <button id="tag-cancel-btn" class="btn-secondary">Cancel</button>
+                <button id="tag-save-btn" class="btn-primary">Save</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Molecule Details Modal -->
     <div id="molecule-details-modal" class="modal">
         <div class="modal-content details-modal">

--- a/src/components/MoleculeCard.js
+++ b/src/components/MoleculeCard.js
@@ -1,11 +1,13 @@
 import ApiService from '../utils/apiService.js';
 
 class MoleculeCard {
-    constructor(grid, repository, callbacks = {}) {
+    constructor(grid, repository, options = {}) {
         this.grid = grid;
         this.repository = repository;
-        this.onDelete = callbacks.onDelete;
-        this.onShowDetails = callbacks.onShowDetails;
+        this.onDelete = options.onDelete;
+        this.onShowDetails = options.onShowDetails;
+        this.tagManager = options.tagManager;
+        this.tagModal = options.tagModal;
         this.draggedElement = null;
     }
 
@@ -61,6 +63,7 @@ class MoleculeCard {
 
         this.grid.appendChild(card);
         this.renderSmilesIn2D(smiles, viewerContainer);
+        this.addTagSection(card, ccdCode);
         this.addDragEvents(card);
     }
 
@@ -121,6 +124,7 @@ class MoleculeCard {
         card.appendChild(viewerContainer);
 
         this.grid.appendChild(card);
+        this.addTagSection(card, ccdCode);
         this.addDragEvents(card);
 
         setTimeout(() => {
@@ -176,6 +180,7 @@ class MoleculeCard {
         card.appendChild(content);
 
         this.grid.appendChild(card);
+        this.addTagSection(card, ccdCode);
         this.addDragEvents(card);
     }
 
@@ -254,6 +259,48 @@ class MoleculeCard {
     clearAll() {
         const allCards = this.grid.querySelectorAll('.molecule-card');
         allCards.forEach(card => card.remove());
+    }
+
+    addTagSection(card, code) {
+        if (!this.tagManager) return;
+        const container = document.createElement('div');
+        container.className = 'tags-container';
+        card.appendChild(container);
+
+        const addBtn = document.createElement('button');
+        addBtn.className = 'add-tag-btn';
+        addBtn.textContent = 'Add tag';
+        addBtn.addEventListener('click', e => {
+            e.stopPropagation();
+            if (this.tagModal) {
+                this.tagModal.open(code, () => this.updateTagsDisplay(container, code));
+            }
+        });
+        card.appendChild(addBtn);
+
+        this.updateTagsDisplay(container, code);
+    }
+
+    updateTagsDisplay(container, code) {
+        if (!this.tagManager) return;
+        container.innerHTML = '';
+        const tags = this.tagManager.getTags(code);
+        tags.forEach(tag => {
+            const span = document.createElement('span');
+            span.className = 'tag';
+            span.textContent = tag;
+
+            const remove = document.createElement('span');
+            remove.className = 'tag-remove';
+            remove.textContent = '×';
+            remove.addEventListener('click', e => {
+                e.stopPropagation();
+                this.tagManager.removeTag(code, tag);
+                this.updateTagsDisplay(container, code);
+            });
+            span.appendChild(remove);
+            container.appendChild(span);
+        });
     }
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,8 @@ import MoleculeCard from './components/MoleculeCard.js';
 import PdbDetailsModal from './modal/PdbDetailsModal.js';
 import AddMoleculeModal from './modal/AddMoleculeModal.js';
 import ProteinBrowser from './components/ProteinBrowser.js';
+import TagManager from './utils/TagManager.js';
+import TagModal from './modal/TagModal.js';
 
 class MoleculeManager {
     constructor() {
@@ -22,15 +24,20 @@ class MoleculeManager {
         this.boundLigandTable = null;
         this.pdbDetailsModal = null;
         this.addModal = null;
+        this.tagManager = new TagManager(this.repository);
+        this.tagModal = null;
     }
 
     init() {
         this.grid = document.getElementById('molecule-grid');
         this.loadingIndicator = document.querySelector('.loading-indicator');
 
+        this.tagModal = new TagModal(this.tagManager);
         this.cardUI = new MoleculeCard(this.grid, this.repository, {
             onDelete: code => this.confirmDelete(code),
-            onShowDetails: (code, data, format) => this.showMoleculeDetails(code, data, format)
+            onShowDetails: (code, data, format) => this.showMoleculeDetails(code, data, format),
+            tagManager: this.tagManager,
+            tagModal: this.tagModal
         });
 
         this.loader = new MoleculeLoader(this.repository, this.cardUI);

--- a/src/modal/TagModal.js
+++ b/src/modal/TagModal.js
@@ -1,0 +1,56 @@
+class TagModal {
+    constructor(tagManager) {
+        this.tagManager = tagManager;
+        this.modal = document.getElementById('tag-modal');
+        this.input = document.getElementById('tag-input');
+        this.saveBtn = document.getElementById('tag-save-btn');
+        this.cancelBtn = document.getElementById('tag-cancel-btn');
+        this.closeBtn = document.getElementById('tag-close-modal');
+        this.currentCode = null;
+        this.onSave = null;
+
+        if (this.saveBtn) {
+            this.saveBtn.addEventListener('click', () => this.handleSave());
+        }
+        if (this.cancelBtn) {
+            this.cancelBtn.addEventListener('click', () => this.close());
+        }
+        if (this.closeBtn) {
+            this.closeBtn.addEventListener('click', () => this.close());
+        }
+        window.addEventListener('click', e => {
+            if (e.target === this.modal) {
+                this.close();
+            }
+        });
+    }
+
+    open(code, onSave) {
+        this.currentCode = code;
+        this.onSave = onSave;
+        if (this.input) this.input.value = '';
+        if (this.modal) {
+            this.modal.style.display = 'block';
+            this.input && this.input.focus();
+        }
+    }
+
+    handleSave() {
+        const value = this.input ? this.input.value.trim() : '';
+        if (value && this.currentCode) {
+            this.tagManager.addTag(this.currentCode, value);
+            if (this.onSave) this.onSave(value);
+        }
+        this.close();
+    }
+
+    close() {
+        if (this.modal) {
+            this.modal.style.display = 'none';
+        }
+        this.currentCode = null;
+        this.onSave = null;
+    }
+}
+
+export default TagModal;

--- a/src/utils/MoleculeRepository.js
+++ b/src/utils/MoleculeRepository.js
@@ -1,6 +1,10 @@
 class MoleculeRepository {
     constructor(initial = []) {
-        this.molecules = initial.map(m => ({ ...m, id: this.generateId(m) }));
+        this.molecules = initial.map(m => ({
+            ...m,
+            id: this.generateId(m),
+            tags: m.tags ? [...m.tags] : []
+        }));
     }
 
     generateId(data) {
@@ -21,9 +25,11 @@ class MoleculeRepository {
             code: typeof data === 'string' ? data : data.code,
             status: 'pending',
             id,
+            tags: []
         };
         if (data && typeof data === 'object') {
             Object.assign(molecule, data);
+            if (!molecule.tags) molecule.tags = [];
         }
         this.molecules.push(molecule);
         return true;
@@ -61,6 +67,40 @@ class MoleculeRepository {
 
     clearAll() {
         this.molecules = [];
+    }
+
+    getTags(identifier) {
+        const mol = this.getMolecule(identifier);
+        return mol && mol.tags ? [...mol.tags] : [];
+    }
+
+    addTag(identifier, tag) {
+        const mol = this.getMolecule(identifier);
+        if (!mol) return false;
+        if (!mol.tags) mol.tags = [];
+        if (!mol.tags.includes(tag)) {
+            mol.tags.push(tag);
+            return true;
+        }
+        return false;
+    }
+
+    updateTag(identifier, oldTag, newTag) {
+        const mol = this.getMolecule(identifier);
+        if (!mol || !mol.tags) return false;
+        const idx = mol.tags.indexOf(oldTag);
+        if (idx === -1) return false;
+        mol.tags[idx] = newTag;
+        return true;
+    }
+
+    removeTag(identifier, tag) {
+        const mol = this.getMolecule(identifier);
+        if (!mol || !mol.tags) return false;
+        const idx = mol.tags.indexOf(tag);
+        if (idx === -1) return false;
+        mol.tags.splice(idx, 1);
+        return true;
     }
 
     removeHydrogensFromSdf(sdf) {

--- a/src/utils/TagManager.js
+++ b/src/utils/TagManager.js
@@ -1,0 +1,23 @@
+class TagManager {
+    constructor(repository) {
+        this.repository = repository;
+    }
+
+    getTags(code) {
+        return this.repository.getTags(code);
+    }
+
+    addTag(code, tag) {
+        return this.repository.addTag(code, tag);
+    }
+
+    updateTag(code, oldTag, newTag) {
+        return this.repository.updateTag(code, oldTag, newTag);
+    }
+
+    removeTag(code, tag) {
+        return this.repository.removeTag(code, tag);
+    }
+}
+
+export default TagManager;

--- a/tests/moleculeRepository.test.js
+++ b/tests/moleculeRepository.test.js
@@ -8,7 +8,7 @@ describe('MoleculeRepository', () => {
     assert.ok(repo.addMolecule('A'));
     assert.strictEqual(repo.addMolecule('A'), false);
     assert.deepStrictEqual(repo.getAllMolecules(), [
-      { code: 'A', status: 'pending', id: 'A' },
+      { code: 'A', status: 'pending', id: 'A', tags: [] },
     ]);
   });
 
@@ -22,6 +22,7 @@ describe('MoleculeRepository', () => {
       authSeqId: '5',
       labelAsymId: 'A',
       id: '1ABC_A_5_B',
+      tags: []
     });
   });
 

--- a/tests/tagManager.test.js
+++ b/tests/tagManager.test.js
@@ -1,0 +1,27 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import MoleculeRepository from '../src/utils/MoleculeRepository.js';
+import TagManager from '../src/utils/TagManager.js';
+
+describe('TagManager', () => {
+  it('adds tags to molecules', () => {
+    const repo = new MoleculeRepository([{ code: 'A', status: 'pending' }]);
+    const tm = new TagManager(repo);
+    assert.ok(tm.addTag('A', 'important'));
+    assert.deepStrictEqual(tm.getTags('A'), ['important']);
+  });
+
+  it('edits existing tags', () => {
+    const repo = new MoleculeRepository([{ code: 'B', status: 'pending', tags: ['old'] }]);
+    const tm = new TagManager(repo);
+    assert.ok(tm.updateTag('B', 'old', 'new'));
+    assert.deepStrictEqual(tm.getTags('B'), ['new']);
+  });
+
+  it('removes tags from molecules', () => {
+    const repo = new MoleculeRepository([{ code: 'C', status: 'pending', tags: ['t1', 't2'] }]);
+    const tm = new TagManager(repo);
+    assert.ok(tm.removeTag('C', 't1'));
+    assert.deepStrictEqual(tm.getTags('C'), ['t2']);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce TagManager to persist molecule tags
- show and edit tags via new TagModal and MoleculeCard UI
- store tags in MoleculeRepository and add tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fe99df27c8329befb9cc487aef159