### PR TITLE
Add interactive tour guide

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
         <h1>ChemLogic Interface</h1>
         <p>Molecular Data Visualization and Pattern Analysis</p>
         <p class="author">By Charlie Harris 🛡️</p>
+        <button id="start-tutorial-btn" class="btn-secondary">Start tutorial</button>
     </header>
     <main>
         <div class="tabs">

--- a/src/components/TourGuide.js
+++ b/src/components/TourGuide.js
@@ -1,0 +1,158 @@
+class TourGuide {
+    constructor(steps = []) {
+        this.steps = steps;
+        this.current = -1;
+        this.overlay = null;
+        this.tooltip = null;
+        this.textEl = null;
+        this.nextBtn = null;
+        this.prevBtn = null;
+        this.boundKeyHandler = this.handleKeyDown.bind(this);
+    }
+
+    start() {
+        if (!this.steps.length) return;
+        this.createOverlay();
+        this.showStep(0);
+        if (document.addEventListener) {
+            document.addEventListener('keydown', this.boundKeyHandler);
+        }
+    }
+
+    createOverlay() {
+        this.overlay = document.createElement('div');
+        this.overlay.className = 'tour-overlay';
+        this.overlay.addEventListener('click', (e) => {
+            if (e.target === this.overlay) {
+                this.next();
+            }
+        });
+
+        this.tooltip = document.createElement('div');
+        this.tooltip.className = 'tour-tooltip';
+        this.textEl = document.createElement('p');
+        this.tooltip.appendChild(this.textEl);
+
+        const btnContainer = document.createElement('div');
+        btnContainer.className = 'tour-controls';
+
+        this.prevBtn = document.createElement('button');
+        this.prevBtn.textContent = 'Back';
+        this.prevBtn.className = 'tour-prev btn-secondary';
+        this.prevBtn.addEventListener('click', () => this.prev());
+
+        this.nextBtn = document.createElement('button');
+        this.nextBtn.textContent = 'Next';
+        this.nextBtn.className = 'tour-next btn-primary';
+        this.nextBtn.addEventListener('click', () => this.next());
+
+        btnContainer.appendChild(this.prevBtn);
+        btnContainer.appendChild(this.nextBtn);
+        this.tooltip.appendChild(btnContainer);
+
+        this.overlay.appendChild(this.tooltip);
+        document.body.appendChild(this.overlay);
+    }
+
+    getElement(step) {
+        if (!step) return null;
+        return typeof step.element === 'string'
+            ? document.querySelector(step.element)
+            : step.element;
+    }
+
+    showStep(index) {
+        if (this.current >= 0) {
+            const prevEl = this.getElement(this.steps[this.current]);
+            if (prevEl) {
+                if (prevEl.classList && prevEl.classList.remove) {
+                    prevEl.classList.remove('tour-highlight');
+                } else {
+                    prevEl.className = prevEl.className.replace('tour-highlight', '').trim();
+                }
+            }
+        }
+
+        if (index >= this.steps.length) {
+            this.end();
+            return;
+        }
+
+        this.current = index;
+        const step = this.steps[index];
+        if (typeof step.onShow === 'function') {
+            step.onShow();
+        }
+        const el = this.getElement(step);
+        if (!el) {
+            this.next();
+            return;
+        }
+        if (el.classList && el.classList.add) {
+            el.classList.add('tour-highlight');
+        } else {
+            el.className = `${el.className ? el.className + ' ' : ''}tour-highlight`;
+        }
+        this.textEl.textContent = step.message || '';
+
+        const rect = typeof el.getBoundingClientRect === 'function'
+            ? el.getBoundingClientRect()
+            : { top: 0, left: 0, height: 0 };
+        if (this.tooltip && this.tooltip.style) {
+            this.tooltip.style.top = `${rect.top + rect.height + 10}px`;
+            this.tooltip.style.left = `${rect.left}px`;
+        }
+
+        if (this.prevBtn && this.prevBtn.style) {
+            this.prevBtn.style.display = index === 0 ? 'none' : 'inline-block';
+        }
+        if (this.nextBtn) {
+            this.nextBtn.textContent = index === this.steps.length - 1 ? 'Finish' : 'Next';
+        }
+    }
+
+    next() {
+        this.showStep(this.current + 1);
+    }
+
+    prev() {
+        if (this.current <= 0) return;
+        this.showStep(this.current - 1);
+    }
+
+    handleKeyDown(e) {
+        const key = e.key;
+        if (['Enter', ' ', 'ArrowRight'].includes(key)) {
+            e.preventDefault && e.preventDefault();
+            this.next();
+        } else if (['ArrowLeft'].includes(key)) {
+            e.preventDefault && e.preventDefault();
+            this.prev();
+        } else if (key === 'Escape') {
+            e.preventDefault && e.preventDefault();
+            this.end();
+        }
+    }
+
+    end() {
+        if (this.current >= 0) {
+            const el = this.getElement(this.steps[this.current]);
+            if (el) {
+                if (el.classList && el.classList.remove) {
+                    el.classList.remove('tour-highlight');
+                } else {
+                    el.className = el.className.replace('tour-highlight', '').trim();
+                }
+            }
+        }
+        this.current = -1;
+        if (document.removeEventListener) {
+            document.removeEventListener('keydown', this.boundKeyHandler);
+        }
+        if (this.overlay && this.overlay.parentNode) {
+            this.overlay.parentNode.removeChild(this.overlay);
+        }
+    }
+}
+
+export default TourGuide;

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ import MoleculeCard from './components/MoleculeCard.js';
 import PdbDetailsModal from './modal/PdbDetailsModal.js';
 import AddMoleculeModal from './modal/AddMoleculeModal.js';
 import ProteinBrowser from './components/ProteinBrowser.js';
+import TourGuide from './components/TourGuide.js';
 
 class MoleculeManager {
     constructor() {
@@ -198,6 +199,29 @@ const fragmentLibrary = new FragmentLibrary(moleculeManager, {
 fragmentLibrary.loadFragments();
 
 const proteinBrowser = new ProteinBrowser(moleculeManager).init();
+
+const tourSteps = [
+    {
+        element: '#add-molecule-btn',
+        message: 'Load molecules by clicking this button to add new entries.'
+    },
+    {
+        element: '#fragment-search',
+        message: 'Search for molecular fragments here.',
+        onShow: () => document.querySelectorAll('.tab-button')[1].click()
+    },
+    {
+        element: '#protein-group-search',
+        message: 'Browse protein structures by entering a group ID.',
+        onShow: () => document.querySelectorAll('.tab-button')[2].click()
+    }
+];
+
+const tourGuide = new TourGuide(tourSteps);
+const startTutorialBtn = document.getElementById('start-tutorial-btn');
+if (startTutorialBtn) {
+    startTutorialBtn.addEventListener('click', () => tourGuide.start());
+}
 
 function showNotification(message, type = 'info') {
     const notification = document.createElement('div');

--- a/style.css
+++ b/style.css
@@ -1568,3 +1568,36 @@ main {
         font-size: 13px;
     }
 }
+/* Tour Guide Styles */
+.tour-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 1000;
+}
+
+.tour-tooltip {
+    position: absolute;
+    background: #fff;
+    color: #333;
+    padding: 15px;
+    border-radius: 6px;
+    max-width: 300px;
+    z-index: 1001;
+}
+
+.tour-highlight {
+    position: relative;
+    z-index: 1002;
+    box-shadow: 0 0 0 4px #ff9800;
+}
+
+.tour-controls {
+    display: flex;
+    gap: 10px;
+    margin-top: 10px;
+    justify-content: flex-end;
+}

--- a/tests/tourGuide.test.js
+++ b/tests/tourGuide.test.js
@@ -1,0 +1,53 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from './domStub.js';
+import TourGuide from '../src/components/TourGuide.js';
+
+let dom;
+let tour;
+let elements;
+
+describe('TourGuide', () => {
+  beforeEach(() => {
+    dom = new JSDOM();
+    const { document } = dom.window;
+    global.document = document;
+    global.window = dom.window;
+    document.body = document.createElement('body');
+
+    elements = {
+      mol: document.createElement('button'),
+      frag: document.createElement('input'),
+      protein: document.createElement('input')
+    };
+    elements.mol.id = 'add-molecule-btn';
+    elements.frag.id = 'fragment-search';
+    elements.protein.id = 'protein-group-search';
+    document.registerElement('add-molecule-btn', elements.mol);
+    document.registerElement('fragment-search', elements.frag);
+    document.registerElement('protein-group-search', elements.protein);
+
+    const steps = [
+      { element: elements.mol, message: 'molecule' },
+      { element: elements.frag, message: 'fragment' },
+      { element: elements.protein, message: 'protein' }
+    ];
+    tour = new TourGuide(steps);
+  });
+
+  it('advances through tutorial steps', () => {
+    tour.start();
+    assert.ok(elements.mol.className.includes('tour-highlight'));
+
+    tour.handleKeyDown({ key: 'Enter', preventDefault: () => {} });
+    assert.ok(elements.frag.className.includes('tour-highlight'));
+
+    tour.next();
+    assert.ok(elements.protein.className.includes('tour-highlight'));
+
+    tour.next();
+    assert.strictEqual(elements.mol.className.includes('tour-highlight'), false);
+    assert.strictEqual(elements.frag.className.includes('tour-highlight'), false);
+    assert.strictEqual(elements.protein.className.includes('tour-highlight'), false);
+  });
+});


### PR DESCRIPTION
## Summary
- add TourGuide component to highlight key UI elements in sequence
- expose Start tutorial button and hook up TourGuide instance
- style tour overlays and tooltips; cover steps in new tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fe9a997a88329b3719a328dd834fc