### PR TITLE
Add guided tour component

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
         <h1>ChemLogic Interface</h1>
         <p>Molecular Data Visualization and Pattern Analysis</p>
         <p class="author">By Charlie Harris 🛡️</p>
+        <button id="start-tour-btn" class="tutorial-btn">Start Tutorial</button>
     </header>
     <main>
         <div class="tabs">

--- a/src/components/TourGuide.js
+++ b/src/components/TourGuide.js
@@ -1,0 +1,100 @@
+export default class TourGuide {
+    constructor(steps = []) {
+        this.steps = steps;
+        this.currentIndex = -1;
+        this.overlay = null;
+        this.tooltip = null;
+        this.currentElement = null;
+    }
+
+    start() {
+        this.currentIndex = -1;
+        this.next();
+    }
+
+    next() {
+        this.cleanup();
+        this.currentIndex++;
+        if (this.currentIndex >= this.steps.length) {
+            this.end();
+            return;
+        }
+        const step = this.steps[this.currentIndex];
+        const el = step.element || (step.selector ? document.querySelector(step.selector) : null);
+        if (!el) {
+            this.next();
+            return;
+        }
+        this.currentElement = el;
+        if (el.classList && el.classList.add) {
+            el.classList.add('tour-highlight');
+        } else {
+            el.className = (el.className ? el.className + ' ' : '') + 'tour-highlight';
+        }
+
+        this.overlay = document.createElement('div');
+        this.overlay.className = 'tour-overlay';
+        document.body.appendChild(this.overlay);
+
+        this.tooltip = document.createElement('div');
+        this.tooltip.className = 'tour-tooltip';
+        const text = document.createElement('div');
+        text.textContent = step.text || '';
+        this.tooltip.appendChild(text);
+        const btn = document.createElement('button');
+        btn.textContent = this.currentIndex === this.steps.length - 1 ? 'Finish' : 'Next';
+        btn.addEventListener('click', () => this.next());
+        this.tooltip.appendChild(btn);
+
+        const rect = el.getBoundingClientRect ? el.getBoundingClientRect() : { left: 0, bottom: 0 };
+        const top = (rect.bottom || rect.top || 0) + (window.scrollY || 0) + 10;
+        const left = (rect.left || 0) + (window.scrollX || 0);
+        this.tooltip.style = this.tooltip.style || {};
+        this.tooltip.style.top = `${top}px`;
+        this.tooltip.style.left = `${left}px`;
+        document.body.appendChild(this.tooltip);
+    }
+
+    cleanup() {
+        if (this.overlay) {
+            this.removeElement(this.overlay);
+            this.overlay = null;
+        }
+        if (this.tooltip) {
+            this.removeElement(this.tooltip);
+            this.tooltip = null;
+        }
+        if (this.currentElement) {
+            if (this.currentElement.classList && this.currentElement.classList.remove) {
+                this.currentElement.classList.remove('tour-highlight');
+            } else {
+                this.currentElement.className = this.currentElement.className.replace(/\btour-highlight\b/, '').trim();
+            }
+            this.currentElement = null;
+        }
+    }
+
+    removeElement(el) {
+        if (!el) return;
+        if (typeof el.remove === 'function') {
+            el.remove();
+            return;
+        }
+        const parent = el.parentNode;
+        if (parent && typeof parent.removeChild === 'function') {
+            parent.removeChild(el);
+            return;
+        }
+        if (document && document.body && document.body.children) {
+            const idx = document.body.children.indexOf(el);
+            if (idx > -1) {
+                document.body.children.splice(idx, 1);
+            }
+        }
+    }
+
+    end() {
+        this.cleanup();
+        this.currentIndex = -1;
+    }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ import MoleculeCard from './components/MoleculeCard.js';
 import PdbDetailsModal from './modal/PdbDetailsModal.js';
 import AddMoleculeModal from './modal/AddMoleculeModal.js';
 import ProteinBrowser from './components/ProteinBrowser.js';
+import TourGuide from './components/TourGuide.js';
 
 class MoleculeManager {
     constructor() {
@@ -198,6 +199,17 @@ const fragmentLibrary = new FragmentLibrary(moleculeManager, {
 fragmentLibrary.loadFragments();
 
 const proteinBrowser = new ProteinBrowser(moleculeManager).init();
+
+const tour = new TourGuide([
+    { selector: '#add-molecule-btn', text: 'Add a molecule to your library.' },
+    { selector: '.tab-button:nth-child(2)', text: 'Browse the fragment library.' },
+    { selector: '.tab-button:nth-child(3)', text: 'Explore protein structures.' }
+]);
+
+const startTourBtn = document.getElementById('start-tour-btn');
+if (startTourBtn) {
+    startTourBtn.addEventListener('click', () => tour.start());
+}
 
 function showNotification(message, type = 'info') {
     const notification = document.createElement('div');

--- a/style.css
+++ b/style.css
@@ -198,6 +198,48 @@ main {
     visibility: hidden;
 }
 
+/* Tour Guide styles */
+.tour-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 1000;
+}
+
+.tour-tooltip {
+    position: absolute;
+    background: #fff;
+    padding: 10px 15px;
+    border-radius: 4px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    z-index: 1002;
+}
+
+.tour-tooltip button {
+    margin-top: 10px;
+}
+
+.tour-highlight {
+    position: relative;
+    z-index: 1001;
+    box-shadow: 0 0 0 4px rgba(255, 255, 0, 0.6);
+}
+
+.tutorial-btn {
+    position: absolute;
+    top: 15px;
+    left: 20px;
+    padding: 6px 10px;
+    border: none;
+    border-radius: 4px;
+    background-color: rgba(0, 0, 0, 0.2);
+    color: white;
+    cursor: pointer;
+}
+
 .toggle-switch-label {
     cursor: pointer;
     text-indent: -9999px;

--- a/tests/tourGuide.test.js
+++ b/tests/tourGuide.test.js
@@ -1,0 +1,49 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM, Element } from './domStub.js';
+import TourGuide from '../src/components/TourGuide.js';
+
+describe('TourGuide', () => {
+    let dom, document, step1, step2, tour;
+
+    beforeEach(() => {
+        dom = new JSDOM();
+        document = dom.window.document;
+        document.body = new Element('body');
+        document.body.removeChild = function(child) {
+            const idx = this.children.indexOf(child);
+            if (idx > -1) this.children.splice(idx, 1);
+            return child;
+        };
+        global.document = document;
+        global.window = { scrollY: 0, scrollX: 0 };
+        step1 = new Element('div');
+        step1.getBoundingClientRect = () => ({ top: 0, bottom: 10, left: 0 });
+        step2 = new Element('div');
+        step2.getBoundingClientRect = () => ({ top: 20, bottom: 30, left: 0 });
+        document.body.appendChild(step1);
+        document.body.appendChild(step2);
+        tour = new TourGuide([
+            { element: step1, text: 'first' },
+            { element: step2, text: 'second' }
+        ]);
+    });
+
+    it('highlights elements sequentially', () => {
+        tour.start();
+        assert.ok(step1.className.includes('tour-highlight'));
+        assert.strictEqual(step2.className.includes('tour-highlight'), false);
+        tour.next();
+        assert.strictEqual(step1.className.includes('tour-highlight'), false);
+        assert.ok(step2.className.includes('tour-highlight'));
+    });
+
+    it('cleans up after completion', () => {
+        tour.start();
+        tour.next(); // step2
+        tour.next(); // finish
+        const overlayExists = document.body.children.some(c => c.className === 'tour-overlay');
+        assert.strictEqual(overlayExists, false);
+        assert.strictEqual(step2.className.includes('tour-highlight'), false);
+    });
+});


### PR DESCRIPTION
## Summary
- Add TourGuide component to show sequential UI walkthrough
- Hook up Start Tutorial button and style tour overlays/tooltip
- Test TourGuide step progression and cleanup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688feeab305083299315f97fbe0cca27