### PR TITLE
Rename project to Ligand Surfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ChemLogic Interface
+# Ligand Surfer
 
-ChemLogic Interface is a demo application for exploring molecular structures, fragments and proteins. It combines local fragment libraries with live data from the PDBe and RCSB APIs to provide quick visualisations and analysis.
+Ligand Surfer is a demo application for exploring molecular structures, fragments and proteins. It combines local fragment libraries with live data from the PDBe and RCSB APIs to provide quick visualisations and analysis.
 
 ## Requirements
 - Node.js 18 or later
@@ -29,7 +29,7 @@ npm test
 
 It is not high quality, nor was it intended for serious scientific research and should be used for educational and illustrative purposes only. Data and calculations may not be accurate or complete.
 
-If you have any suggestions for improvements, feel free to write an issue at [github.com/cch1999/molexplorer/issues](https://github.com/cch1999/molexplorer/issues) and the author will endeavour to blindly paste this as a prompt into Cursor Agent Mode.
+If you have any suggestions for improvements, feel free to write an issue at [github.com/cch1999/ligand-surfer/issues](https://github.com/cch1999/ligand-surfer/issues) and the author will endeavour to blindly paste this as a prompt into Cursor Agent Mode.
 
 *Best - Charlie*
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ChemLogic Interface</title>
+    <title>Ligand Surfer</title>
     <link rel="stylesheet" href="style.css" />
 </head>
 
@@ -21,8 +21,8 @@
                     educational and illustrative purposes only. Data and calculations may not be accurate or complete.
                 </p>
                 <p>That being said, if you have any suggestions for improvements, feel free to write an issue at <a
-                        href="https://github.com/cch1999/molexplorer/issues"
-                        target="_blank">github.com/cch1999/molexplorer/issues</a> and I will endeavour to blindly paste
+                        href="https://github.com/cch1999/ligand-surfer/issues"
+                        target="_blank">github.com/cch1999/ligand-surfer/issues</a> and I will endeavour to blindly paste
                     this as a prompt into Cursor Agent Mode.</p>
                 <p><em>Best - Charlie</em></p>
             </div>
@@ -34,7 +34,7 @@
 
     <!-- Main App Content -->
     <header>
-        <h1>ChemLogic Interface</h1>
+        <h1>Ligand Surfer</h1>
         <p>Molecular Data Visualization and Pattern Analysis</p>
         <p class="author">By Charlie Harris 🛡️</p>
     </header>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "molexplorer",
+  "name": "ligand-surfer",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "molexplorer",
+      "name": "ligand-surfer",
       "version": "0.0.0",
       "dependencies": {
         "smiles-drawer": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "molexplorer",
+  "name": "ligand-surfer",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/private/dev.ipynb
+++ b/private/dev.ipynb
@@ -525,9 +525,9 @@
     "import rdkit\n",
     "import rdkit.Chem as Chem\n",
     "\n",
-    "fragment_library = pd.read_csv(\"/Users/charlie/projects/vibes/molexplorer/data/fragment_library.tsv\", sep=\"\\t\")\n",
+    "fragment_library = pd.read_csv(\"/Users/charlie/projects/vibes/ligand-surfer/data/fragment_library.tsv\", sep=\"\\t\")\n",
     "\n",
-    "smiles_ccd = pd.read_csv(\"/Users/charlie/projects/vibes/molexplorer/data/Components-smiles-oe.smi\", sep=\"\\t\", header=None)\n",
+    "smiles_ccd = pd.read_csv(\"/Users/charlie/projects/vibes/ligand-surfer/data/Components-smiles-oe.smi\", sep=\"\\t\", header=None)\n",
     "\n",
     "# Add headers\n",
     "smiles_ccd.columns = [\"smiles\", \"ccd\", \"name\"]\n",
@@ -592,7 +592,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fragment_library.to_csv(\"/Users/charlie/projects/vibes/molexplorer/data/fragment_library_ccd.tsv\", sep=\"\\t\")"
+    "fragment_library.to_csv(\"/Users/charlie/projects/vibes/ligand-surfer/data/fragment_library_ccd.tsv\", sep=\"\\t\")"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- rebrand ChemLogic Interface to **Ligand Surfer** in docs and UI
- update package name and issue links

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ff082017883299f36dd22bff6f726