### PR TITLE
Add 3D structure viewer component and modal controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -271,6 +271,11 @@
 
                 <div class="details-section">
                     <h4>Interactive Molecular Structure</h4>
+                    <div class="viewer-controls">
+                        <button id="ligand-rotate-btn" class="viewer-btn">Rotate</button>
+                        <button id="ligand-zoom-btn" class="viewer-btn">Zoom</button>
+                        <button id="ligand-reset-btn" class="viewer-btn">Reset</button>
+                    </div>
                     <div id="details-viewer-container" class="details-viewer">
                         <p>Loading structure...</p>
                     </div>
@@ -358,8 +363,13 @@
                 <!-- Content will be populated by JavaScript -->
                 <div class="properties-loading">Loading PDB entry details...</div>
             </div>
+            <div class="viewer-controls">
+                <button id="pdb-rotate-btn" class="viewer-btn">Rotate</button>
+                <button id="pdb-zoom-btn" class="viewer-btn">Zoom</button>
+                <button id="pdb-reset-btn" class="viewer-btn">Reset</button>
+            </div>
             <div id="pdb-viewer-container" class="details-viewer" style="display: none;">
-                <!-- 3Dmol.js viewer will be inserted here -->
+                <!-- 3D viewer will be inserted here -->
             </div>
             <div id="bound-ligands-section" class="details-section" style="display: none;">
                 <div class="section-header">

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "molexplorer",
       "version": "0.0.0",
       "dependencies": {
-        "smiles-drawer": "^2.0.1"
+        "3dmol": "^2.5.2"
       },
       "devDependencies": {
         "vite": "^5.2.0"
@@ -692,11 +692,21 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/chroma-js": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.6.0.tgz",
-      "integrity": "sha512-BLHvCB9s8Z1EV4ethr6xnkl/P2YRFOGqfgvuMG/MyCbZPrTA+NeiByY6XvgF0zP4/2deU2CXnWyMa3zu1LqQ3A==",
-      "license": "(BSD-3-Clause AND Apache-2.0)"
+    "node_modules/3dmol": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/3dmol/-/3dmol-2.5.2.tgz",
+      "integrity": "sha512-xILRLpHru+Hoa4kGISfh0QQlI39UoSxRR4q/BKrLNRhsu+LLiE6lfZ6MROHQXKo8iE2alQRWUxSM0mxXmVAvOg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "iobuffer": "^5.0.0",
+        "netcdfjs": "^3.0.0",
+        "pako": "^2.1.0",
+        "upng-js": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=16.16.0",
+        "npm": ">=8.11"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -752,6 +762,12 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -770,6 +786,21 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/netcdfjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/netcdfjs/-/netcdfjs-3.0.0.tgz",
+      "integrity": "sha512-LOvT8KkC308qtpUkcBPiCMBtii7ZQCN6LxcVheWgyUeZ6DQWcpSRFV9dcVXLj/2eHZ/bre9tV5HTH4Sf93vrFw==",
+      "license": "MIT",
+      "dependencies": {
+        "iobuffer": "^5.3.2"
+      }
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -847,15 +878,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/smiles-drawer": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/smiles-drawer/-/smiles-drawer-2.1.7.tgz",
-      "integrity": "sha512-gApm5tsWrAYDkjbGYQb5OhwIyHvtM2kIO40DfATaOV0DPm0wA63yn4Ow7us27BT49lDdU9busCOPN9fpyonzaA==",
-      "license": "MIT",
-      "dependencies": {
-        "chroma-js": "^2.4.2"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -865,6 +887,21 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/upng-js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/upng-js/-/upng-js-2.1.0.tgz",
+      "integrity": "sha512-d3xzZzpMP64YkjP5pr8gNyvBt7dLk/uGI67EctzDuVp4lCZyVMo0aJO6l/VDlgbInJYDY6cnClLoBp29eKWI6g==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.5"
+      }
+    },
+    "node_modules/upng-js/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/vite": {
       "version": "5.4.19",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "node --test"
+    "test": "node --test --experimental-test-module-mocks"
   },
   "devDependencies": {
     "vite": "^5.2.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "3dmol": "^2.5.2"
+  }
 }

--- a/src/components/StructureViewer.js
+++ b/src/components/StructureViewer.js
@@ -1,0 +1,87 @@
+class StructureViewer {
+    constructor(container, molLib = window.$3Dmol) {
+        this.container = container;
+        this.$3Dmol = molLib;
+        this.viewer = null;
+        this.isSpinning = false;
+    }
+
+    init() {
+        if (this.viewer || !this.container) return;
+        try {
+            this.viewer = this.$3Dmol.createViewer(this.container, {
+                backgroundColor: 'white',
+                width: '100%',
+                height: '100%'
+            });
+        } catch (err) {
+            console.error('Failed to initialize viewer', err);
+            if (this.container) {
+                this.container.innerHTML = '<p style="color:#666;">Viewer error</p>';
+            }
+        }
+    }
+
+    loadModel(data, format) {
+        if (!data) {
+            if (this.container) {
+                this.container.innerHTML = '<p style="color:#666;">Structure data not available</p>';
+            }
+            return;
+        }
+        this.init();
+        if (!this.viewer) return;
+        try {
+            this.viewer.clear();
+            this.viewer.addModel(data, format);
+            if (format === 'pdb') {
+                this.viewer.setStyle({}, { cartoon: { color: 'spectrum' } });
+            } else {
+                this.viewer.setStyle({}, { stick: { radius: 0.2 }, sphere: { scale: 0.3 } });
+                this.viewer.setStyle({ elem: 'H' }, {});
+            }
+            this.viewer.zoomTo();
+            this.viewer.render();
+        } catch (err) {
+            console.error('Error rendering structure', err);
+            if (this.container) {
+                this.container.innerHTML = '<p style="color:#666;">Structure rendering error</p>';
+            }
+        }
+    }
+
+    loadSDF(data) {
+        this.loadModel(data, 'sdf');
+    }
+
+    loadPDB(data) {
+        this.loadModel(data, 'pdb');
+    }
+
+    toggleRotate() {
+        if (!this.viewer) return;
+        this.isSpinning = !this.isSpinning;
+        if (this.isSpinning) {
+            this.viewer.spin('y', 1);
+        } else {
+            this.viewer.stopSpin();
+        }
+    }
+
+    zoom(factor = 1.2) {
+        if (this.viewer) {
+            this.viewer.zoom(factor);
+        }
+    }
+
+    reset() {
+        if (this.viewer) {
+            this.viewer.stopSpin();
+            this.isSpinning = false;
+            this.viewer.zoomTo();
+            this.viewer.render();
+        }
+    }
+}
+
+export default StructureViewer;

--- a/src/modal/LigandDetails.js
+++ b/src/modal/LigandDetails.js
@@ -13,7 +13,6 @@ class LigandDetails {
         this.detailsResidue = document.getElementById('details-residue');
         this.detailsViewer = document.getElementById('details-viewer-container');
         this.detailsJSON = document.getElementById('details-json');
-        this.viewer = null;
 
         const closeBtn = document.getElementById('close-details-modal');
         if (closeBtn) {
@@ -57,24 +56,7 @@ class LigandDetails {
 
         this.detailsViewer.innerHTML = '<p>Loading structure...</p>';
         if (sdfData) {
-            setTimeout(() => {
-                try {
-                    const viewer = $3Dmol.createViewer(this.detailsViewer, {
-                        backgroundColor: 'white',
-                        width: '100%',
-                        height: '100%'
-                    });
-                    viewer.addModel(sdfData, 'sdf');
-                    viewer.setStyle({}, { stick: { radius: 0.2 }, sphere: { scale: 0.3 } });
-                    viewer.setStyle({ elem: 'H' }, {});
-                    viewer.zoomTo();
-                    viewer.render();
-                    this.viewer = viewer;
-                } catch (e) {
-                    console.error(`Error initializing details viewer for ${ccdCode}:`, e);
-                    this.detailsViewer.innerHTML = '<p style="color: #666;">Structure rendering error</p>';
-                }
-            }, 100);
+            this.detailsViewer.innerHTML = '';
         } else {
             this.detailsViewer.innerHTML = '<p style="color: #666;">Structure data not available</p>';
         }
@@ -110,19 +92,6 @@ class LigandDetails {
     }
 
     cleanupViewer() {
-        if (this.viewer) {
-            try {
-                this.viewer.clear();
-                if (typeof this.viewer.destroy === 'function') {
-                    this.viewer.destroy();
-                } else if (this.viewer?.gl && typeof this.viewer.gl.getExtension === 'function') {
-                    this.viewer.gl.getExtension('WEBGL_lose_context')?.loseContext();
-                }
-            } catch (e) {
-                console.warn('Error destroying viewer:', e);
-            }
-            this.viewer = null;
-        }
         if (this.detailsViewer) {
             this.detailsViewer.innerHTML = '';
         }

--- a/src/modal/LigandModal.js
+++ b/src/modal/LigandModal.js
@@ -3,19 +3,29 @@ import SimilarLigandTable from './SimilarLigandTable.js';
 import PdbEntryList from './PdbEntryList.js';
 import PropertyCalculator from '../utils/propertyCalculator.js';
 import ApiService from '../utils/apiService.js';
+import StructureViewer from '../components/StructureViewer.js';
 
 class LigandModal {
-    constructor(moleculeManager) {
+    constructor(moleculeManager, ViewerClass = StructureViewer) {
         this.details = new LigandDetails(moleculeManager);
         this.similarLigandTable = new SimilarLigandTable(moleculeManager);
         this.pdbEntryList = new PdbEntryList(moleculeManager);
         this.propertiesContainer = document.getElementById('ligand-properties');
+
+        this.viewer = new ViewerClass(document.getElementById('details-viewer-container'));
+        const rot = document.getElementById('ligand-rotate-btn');
+        if (rot) rot.addEventListener('click', () => this.viewer.toggleRotate());
+        const zoom = document.getElementById('ligand-zoom-btn');
+        if (zoom) zoom.addEventListener('click', () => this.viewer.zoom());
+        const reset = document.getElementById('ligand-reset-btn');
+        if (reset) reset.addEventListener('click', () => this.viewer.reset());
     }
 
     show(ccdCode, sdfData) {
         this.details.show(ccdCode, sdfData);
         this.similarLigandTable.load(ccdCode);
         this.pdbEntryList.load(ccdCode);
+        this.viewer.loadSDF(sdfData);
 
         if (this.propertiesContainer) {
             this.propertiesContainer.textContent = 'Loading properties...';

--- a/src/modal/PdbDetailsModal.js
+++ b/src/modal/PdbDetailsModal.js
@@ -1,5 +1,6 @@
 import ApiService from '../utils/apiService.js';
 import { RCSB_STRUCTURE_BASE_URL, PD_BE_ENTRY_BASE_URL } from '../utils/constants.js';
+import StructureViewer from '../components/StructureViewer.js';
 
 class PdbDetailsModal {
     constructor(boundLigandTable) {
@@ -14,6 +15,14 @@ class PdbDetailsModal {
                 this.close();
             }
         });
+
+        this.viewer = new StructureViewer(document.getElementById('pdb-viewer-container'));
+        const rot = document.getElementById('pdb-rotate-btn');
+        if (rot) rot.addEventListener('click', () => this.viewer.toggleRotate());
+        const zoom = document.getElementById('pdb-zoom-btn');
+        if (zoom) zoom.addEventListener('click', () => this.viewer.zoom());
+        const reset = document.getElementById('pdb-reset-btn');
+        if (reset) reset.addEventListener('click', () => this.viewer.reset());
     }
 
     async fetchRCSBDetails(pdbId) {
@@ -56,25 +65,9 @@ class PdbDetailsModal {
             });
 
             viewerContainer.style.display = 'block';
-            viewerContainer.innerHTML = '<p class="properties-loading">Loading 3D structure...</p>';
+            viewerContainer.innerHTML = '';
             const pdbData = await ApiService.getPdbFile(pdbId);
-
-            setTimeout(() => {
-                try {
-                    const viewer = $3Dmol.createViewer(viewerContainer, {
-                        backgroundColor: 'white',
-                        width: '100%',
-                        height: '100%'
-                    });
-                    viewer.addModel(pdbData, 'pdb');
-                    viewer.setStyle({}, { cartoon: { color: 'spectrum' } });
-                    viewer.zoomTo();
-                    viewer.render();
-                } catch (e) {
-                    console.error('Error creating 3Dmol viewer:', e);
-                    viewerContainer.innerHTML = '<div class="no-pdb-entries">Could not render 3D structure.</div>';
-                }
-            }, 100);
+            this.viewer.loadPDB(pdbData);
         } catch (error) {
             console.error('Error fetching PDB details:', error);
             body.innerHTML = '<div class="no-pdb-entries">Could not load details for this PDB entry.</div>';

--- a/tests/ligandModal.test.js
+++ b/tests/ligandModal.test.js
@@ -7,6 +7,8 @@ import PdbEntryList from '../src/modal/PdbEntryList.js';
 import PropertyCalculator from '../src/utils/propertyCalculator.js';
 import ApiService from '../src/utils/apiService.js';
 
+class DummyViewer { constructor() {} loadSDF() {} toggleRotate() {} zoom() {} reset() {} }
+
 describe('LigandModal orchestrator', () => {
   it('delegates to subcomponents', () => {
     const makeEl = () => ({ style: {}, addEventListener: () => {}, innerHTML: '', textContent: '' });
@@ -24,7 +26,7 @@ describe('LigandModal orchestrator', () => {
     mock.method(PropertyCalculator, 'getProperties', async () => null);
     mock.method(ApiService, 'getPubChemMetadata', async () => null);
 
-    const lm = new LigandModal({});
+    const lm = new LigandModal({}, DummyViewer);
     lm.show('ATP', 'sdf');
     lm.load2DStructure('ATP', 'container');
 
@@ -60,7 +62,7 @@ describe('LigandModal properties panel', () => {
     mock.method(PropertyCalculator, 'getProperties', async () => ({ molecularWeight: 55, formula: 'C2H6O' }));
     mock.method(ApiService, 'getPubChemMetadata', async () => ({ properties: null, synonyms: [], link: null }));
 
-    const lm = new LigandModal({});
+    const lm = new LigandModal({}, DummyViewer);
     lm.show('ETH', 'sdf');
     await new Promise(setImmediate);
     assert.ok(propsEl.innerHTML.includes('55'));
@@ -85,7 +87,7 @@ describe('LigandModal properties panel', () => {
     mock.method(PropertyCalculator, 'getProperties', async () => { throw new Error('fail'); });
     mock.method(ApiService, 'getPubChemMetadata', async () => { throw new Error('fail'); });
 
-    const lm = new LigandModal({});
+    const lm = new LigandModal({}, DummyViewer);
     lm.show('BAD', 'sdf');
     await new Promise(setImmediate);
     assert.strictEqual(propsEl.textContent, 'Properties unavailable');
@@ -117,7 +119,7 @@ describe('LigandModal metadata retrieval', () => {
       link: 'https://pubchem.ncbi.nlm.nih.gov/compound/123'
     }));
 
-    const lm = new LigandModal({});
+    const lm = new LigandModal({}, DummyViewer);
     lm.show('WAT', 'sdf');
     await new Promise(setImmediate);
     assert.ok(propsEl.innerHTML.includes('Foo'));


### PR DESCRIPTION
## Summary
- introduce reusable StructureViewer class with rotation, zoom, and reset support
- wire viewer into ligand and PDB modals with on-screen controls
- add 3dmol dependency and adjust tests for stubbed viewer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ff03095dc8329b98123cba4cfdb86