### PR TITLE
Focus ligand view on PDB instance

### DIFF
--- a/src/modal/LigandDetails.js
+++ b/src/modal/LigandDetails.js
@@ -1,3 +1,5 @@
+import ApiService from '../utils/apiService.js';
+
 class LigandDetails {
     constructor(moleculeManager) {
         this.moleculeManager = moleculeManager;
@@ -56,7 +58,37 @@ class LigandDetails {
         }
 
         this.detailsViewer.innerHTML = '<p>Loading structure...</p>';
-        if (sdfData) {
+        if (isInstance) {
+            ApiService.getPdbFile(molecule.pdbId)
+                .then(pdbData => {
+                    setTimeout(() => {
+                        try {
+                            const viewer = $3Dmol.createViewer(this.detailsViewer, {
+                                backgroundColor: 'white',
+                                width: '100%',
+                                height: '100%'
+                            });
+                            viewer.addModel(pdbData, 'pdb');
+                            viewer.setStyle({}, { cartoon: { color: 'spectrum' } });
+                            const selection = {
+                                chain: molecule.labelAsymId,
+                                resi: parseInt(molecule.authSeqId, 10)
+                            };
+                            viewer.setStyle(selection, { stick: { radius: 0.25, colorscheme: 'greenCarbon' } });
+                            viewer.zoomTo(selection);
+                            viewer.render();
+                            this.viewer = viewer;
+                        } catch (e) {
+                            console.error(`Error initializing PDB viewer for ${ccdCode}:`, e);
+                            this.detailsViewer.innerHTML = '<p style="color: #666;">Structure rendering error</p>';
+                        }
+                    }, 100);
+                })
+                .catch(e => {
+                    console.error(`Error fetching PDB for ${ccdCode}:`, e);
+                    this.detailsViewer.innerHTML = '<p style="color: #666;">Structure data not available</p>';
+                });
+        } else if (sdfData) {
             setTimeout(() => {
                 try {
                     const viewer = $3Dmol.createViewer(this.detailsViewer, {

--- a/tests/ligandDetails.test.js
+++ b/tests/ligandDetails.test.js
@@ -1,0 +1,85 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import LigandDetails from '../src/modal/LigandDetails.js';
+import ApiService from '../src/utils/apiService.js';
+import { JSDOM, Element } from './domStub.js';
+
+const makeEl = () => ({
+  style: {},
+  addEventListener: () => {},
+  innerHTML: '',
+  textContent: ''
+});
+
+describe('LigandDetails viewer focus', () => {
+  it('focuses on ligand when showing PDB instance', async () => {
+    const dom = new JSDOM();
+    const { document } = dom.window;
+
+    // Required elements
+    const modalEl = makeEl();
+    const titleEl = makeEl();
+    const codeEl = makeEl();
+    const sourceEl = makeEl();
+    const typeEl = makeEl();
+    const structEl = makeEl();
+    const pdbEl = makeEl();
+    const chainEl = makeEl();
+    const resEl = makeEl();
+    const viewerEl = makeEl();
+    const jsonEl = makeEl();
+
+    document.registerElement('molecule-details-modal', modalEl);
+    document.registerElement('details-title', titleEl);
+    document.registerElement('details-code', codeEl);
+    document.registerElement('details-source', sourceEl);
+    document.registerElement('details-type', typeEl);
+    document.registerElement('details-structure', structEl);
+    document.registerElement('details-pdb-id', pdbEl);
+    document.registerElement('details-chain', chainEl);
+    document.registerElement('details-residue', resEl);
+    document.registerElement('details-viewer-container', viewerEl);
+    document.registerElement('details-json', jsonEl);
+
+    global.document = document;
+    global.document.querySelectorAll = (sel) =>
+      sel === '.pdb-instance-field' ? [pdbEl, chainEl, resEl] : [];
+    global.window = { addEventListener: () => {} };
+
+    const moleculeManager = {
+      getMolecule: () => ({
+        code: 'ATP',
+        pdbId: '1abc',
+        labelAsymId: 'B',
+        authSeqId: '5'
+      })
+    };
+
+    mock.method(ApiService, 'getPdbFile', async () => 'PDBDATA');
+
+    const viewer = {
+      addModel: mock.fn(),
+      setStyle: mock.fn(),
+      zoomTo: mock.fn(),
+      render: mock.fn(),
+      clear: () => {},
+      destroy: () => {}
+    };
+    global.$3Dmol = { createViewer: mock.fn(() => viewer) };
+    mock.method(global, 'setTimeout', (fn) => { fn(); });
+
+    const ld = new LigandDetails(moleculeManager);
+    ld.show('ATP');
+    await new Promise(setImmediate);
+
+    assert.strictEqual(ApiService.getPdbFile.mock.callCount(), 1);
+    assert.deepStrictEqual(ApiService.getPdbFile.mock.calls[0].arguments, ['1abc']);
+    assert.strictEqual(viewer.zoomTo.mock.callCount(), 1);
+    assert.deepStrictEqual(viewer.zoomTo.mock.calls[0].arguments, [{ chain: 'B', resi: 5 }]);
+
+    mock.restoreAll();
+    delete global.$3Dmol;
+    delete global.document;
+    delete global.window;
+  });
+});


### PR DESCRIPTION
## Summary
- center 3D viewer on ligand when displaying a PDB instance
- highlight ligand against protein cartoon
- add regression test for ligand-focused viewer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ff3768b188329b6f6c5ccabb2afdd