### PR TITLE
Rename project to Ligand Surfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ChemLogic Interface
+# Ligand Surfer
 
-ChemLogic Interface is a demo application for exploring molecular structures, fragments and proteins. It combines local fragment libraries with live data from the PDBe and RCSB APIs to provide quick visualisations and analysis.
+Ligand Surfer is a demo application for exploring molecular structures, fragments and proteins. It combines local fragment libraries with live data from the PDBe and RCSB APIs to provide quick visualisations and analysis.
 
 ## Requirements
 - Node.js 18 or later

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ChemLogic Interface</title>
+    <title>Ligand Surfer</title>
     <link rel="stylesheet" href="style.css" />
 </head>
 
@@ -34,8 +34,8 @@
 
     <!-- Main App Content -->
     <header>
-        <h1>ChemLogic Interface</h1>
-        <p>Molecular Data Visualization and Pattern Analysis</p>
+        <h1>Ligand Surfer</h1>
+        <p>Interactive exploration of ligands, fragments, and proteins</p>
         <p class="author">By Charlie Harris 🛡️</p>
     </header>
     <main>


### PR DESCRIPTION
## Summary
- rename project to **Ligand Surfer**
- update app subtitle to better reflect ligand, fragment, and protein exploration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ff4952d108329aa4c1a245ada958c