### PR TITLE
Show SMILES in ligand modal

### DIFF
--- a/src/modal/LigandModal.js
+++ b/src/modal/LigandModal.js
@@ -31,9 +31,13 @@ class LigandModal {
                     let html = '';
                     const weight = meta?.properties?.MolecularWeight ?? calcProps?.molecularWeight;
                     const formula = meta?.properties?.MolecularFormula ?? calcProps?.formula;
+                    const smiles = meta?.properties?.CanonicalSMILES;
                     if (weight || formula) {
                         html += `<div>Molecular Weight: ${weight ?? 'N/A'}</div>`;
                         html += `<div>Formula: ${formula ?? 'N/A'}</div>`;
+                    }
+                    if (smiles) {
+                        html += `<div>SMILES: ${smiles}</div>`;
                     }
                     if (meta?.properties?.IUPACName) {
                         html += `<div>IUPAC Name: ${meta.properties.IUPACName}</div>`;

--- a/tests/ligandModal.test.js
+++ b/tests/ligandModal.test.js
@@ -99,7 +99,7 @@ describe('LigandModal properties panel', () => {
 describe('LigandModal metadata retrieval', () => {
   const makeEl = () => ({ style: {}, addEventListener: () => {}, innerHTML: '', textContent: '' });
 
-  it('renders synonyms and link from ApiService', async () => {
+  it('renders SMILES, synonyms and link from ApiService', async () => {
     const propsEl = makeEl();
     global.document = {
       getElementById: (id) => (id === 'ligand-properties' ? propsEl : makeEl()),
@@ -113,7 +113,7 @@ describe('LigandModal metadata retrieval', () => {
     mock.method(PropertyCalculator, 'getProperties', async () => null);
     mock.method(ApiService, 'getPubChemMetadata', async () => ({
       synonyms: ['Foo', 'Bar'],
-      properties: { MolecularWeight: 10, MolecularFormula: 'H2O' },
+      properties: { MolecularWeight: 10, MolecularFormula: 'H2O', CanonicalSMILES: 'C1CCCCC1' },
       link: 'https://pubchem.ncbi.nlm.nih.gov/compound/123'
     }));
 
@@ -121,6 +121,7 @@ describe('LigandModal metadata retrieval', () => {
     lm.show('WAT', 'sdf');
     await new Promise(setImmediate);
     assert.ok(propsEl.innerHTML.includes('Foo'));
+    assert.ok(propsEl.innerHTML.includes('C1CCCCC1'));
     assert.ok(propsEl.innerHTML.includes('PubChem Entry'));
 
     mock.restoreAll();


### PR DESCRIPTION
## Summary
- display canonical SMILES in ligand modal properties panel
- test PubChem metadata rendering including SMILES

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ff50015ac8329900c02ce0fdf7652