### PR TITLE
Rename problem to Ligand Surfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# ChemLogic Interface
+# Ligand Surfer
 
-ChemLogic Interface is a demo application for exploring molecular structures, fragments and proteins. It combines local fragment libraries with live data from the PDBe and RCSB APIs to provide quick visualisations and analysis.
+**Interactive Ligand Exploration and Analysis**
+
+Ligand Surfer is a demo application for exploring molecular structures, fragments and proteins. It combines local fragment libraries with live data from the PDBe and RCSB APIs to provide quick visualisations and analysis.
 
 ## Requirements
 - Node.js 18 or later

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ChemLogic Interface</title>
+    <title>Ligand Surfer</title>
     <link rel="stylesheet" href="style.css" />
 </head>
 
@@ -34,8 +34,8 @@
 
     <!-- Main App Content -->
     <header>
-        <h1>ChemLogic Interface</h1>
-        <p>Molecular Data Visualization and Pattern Analysis</p>
+        <h1>Ligand Surfer</h1>
+        <p>Interactive Ligand Exploration and Analysis</p>
         <p class="author">By Charlie Harris 🛡️</p>
     </header>
     <main>


### PR DESCRIPTION
## Summary
- rename ChemLogic Interface to Ligand Surfer
- update subtitle to "Interactive Ligand Exploration and Analysis"

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ff4c671588329b684a7d375f6f92b