### PR TITLE
feat: visualize ligand interactions

### DIFF
--- a/src/modal/LigandDetails.js
+++ b/src/modal/LigandDetails.js
@@ -16,6 +16,8 @@ class LigandDetails {
         this.detailsViewer = document.getElementById('details-viewer-container');
         this.detailsJSON = document.getElementById('details-json');
         this.viewer = null;
+        this.interactionShapes = [];
+        this.interactionToggle = null;
 
         const closeBtn = document.getElementById('close-details-modal');
         if (closeBtn) {
@@ -58,6 +60,32 @@ class LigandDetails {
         }
 
         this.detailsViewer.innerHTML = '<p>Loading structure...</p>';
+        this.clearInteractions();
+        if (isInstance && this.detailsViewer?.parentElement) {
+            if (!this.interactionToggle) {
+                const container = document.createElement('div');
+                const checkbox = document.createElement('input');
+                checkbox.type = 'checkbox';
+                checkbox.id = 'interaction-toggle';
+                checkbox.checked = true;
+                const label = document.createElement('label');
+                label.htmlFor = 'interaction-toggle';
+                label.textContent = 'Show interactions';
+                container.appendChild(checkbox);
+                container.appendChild(label);
+                this.detailsViewer.parentElement.insertBefore(container, this.detailsViewer);
+                checkbox.addEventListener('change', () => this.updateInteractionVisibility());
+                this.interactionToggle = checkbox;
+            } else {
+                this.interactionToggle.checked = true;
+                if (this.interactionToggle.parentElement) {
+                    this.interactionToggle.parentElement.style.display = 'block';
+                }
+            }
+        } else if (this.interactionToggle?.parentElement) {
+            this.interactionToggle.parentElement.style.display = 'none';
+        }
+
         if (isInstance) {
             ApiService.getPdbFile(molecule.pdbId)
                 .then(pdbData => {
@@ -78,6 +106,15 @@ class LigandDetails {
                             viewer.zoomTo(selection);
                             viewer.render();
                             this.viewer = viewer;
+                            if (this.interactionToggle) {
+                                ApiService.getLigandInteractions(
+                                    molecule.pdbId,
+                                    molecule.labelAsymId,
+                                    molecule.authSeqId
+                                )
+                                    .then(data => this.renderInteractions(data, molecule))
+                                    .catch(err => console.error('Interaction fetch error:', err));
+                            }
                         } catch (e) {
                             console.error(`Error initializing PDB viewer for ${ccdCode}:`, e);
                             this.detailsViewer.innerHTML = '<p style="color: #666;">Structure rendering error</p>';
@@ -158,6 +195,59 @@ class LigandDetails {
         if (this.detailsViewer) {
             this.detailsViewer.innerHTML = '';
         }
+        this.clearInteractions();
+    }
+
+    renderInteractions(data, molecule) {
+        if (!this.viewer || !data) return;
+        const pdbId = Object.keys(data)[0];
+        const chain = molecule.labelAsymId;
+        const res = String(molecule.authSeqId);
+        const entries = data?.[pdbId]?.[chain]?.[res] || [];
+        entries.forEach(inter => {
+            const ligandAtom = inter?.ligand_atom?.atom || inter?.ligand_atom || inter?.atom;
+            const partnerChain = inter?.partner_chain || inter?.chain_id || inter?.partner?.chain_id;
+            const partnerRes = parseInt(
+                inter?.partner_residue_number || inter?.residue_number || inter?.partner?.residue_number,
+                10
+            );
+            const partnerAtom = inter?.partner_atom || inter?.atom2 || inter?.partner?.atom;
+            const [a1] = this.viewer.getModel().selectedAtoms({ chain, resi: parseInt(res, 10), atom: ligandAtom });
+            const [a2] = this.viewer.getModel().selectedAtoms({ chain: partnerChain, resi: partnerRes, atom: partnerAtom });
+            if (a1 && a2) {
+                const shape = this.viewer.addCylinder({
+                    start: { x: a1.x, y: a1.y, z: a1.z },
+                    end: { x: a2.x, y: a2.y, z: a2.z },
+                    radius: 0.1,
+                    color: 'magenta',
+                    dashed: true
+                });
+                this.interactionShapes.push(shape);
+            }
+        });
+        this.updateInteractionVisibility();
+    }
+
+    updateInteractionVisibility() {
+        const visible = !this.interactionToggle || this.interactionToggle.checked;
+        this.interactionShapes.forEach(shape => {
+            shape.hidden = !visible;
+        });
+        if (this.viewer?.render) this.viewer.render();
+    }
+
+    clearInteractions() {
+        if (this.viewer && this.interactionShapes.length) {
+            this.interactionShapes.forEach(shape => {
+                if (this.viewer.removeShape) {
+                    this.viewer.removeShape(shape);
+                } else {
+                    shape.hidden = true;
+                }
+            });
+            if (this.viewer.render) this.viewer.render();
+        }
+        this.interactionShapes = [];
     }
 }
 

--- a/src/utils/apiService.js
+++ b/src/utils/apiService.js
@@ -19,6 +19,7 @@ import {
   PD_BE_SUMMARY_BASE_URL,
   RCSB_PDB_DOWNLOAD_BASE_URL,
   PD_BE_LIGAND_MONOMERS_BASE_URL,
+  PD_BE_INTERACTIONS_BASE_URL,
   RCSB_GROUP_BASE_URL,
   PUBCHEM_COMPOUND_BASE_URL,
   PUBCHEM_COMPOUND_LINK_BASE
@@ -286,6 +287,23 @@ export default class ApiService {
    */
   static getLigandMonomers(pdbId) {
     return this.fetchJson(`${PD_BE_LIGAND_MONOMERS_BASE_URL}/${pdbId}`);
+  }
+
+  /**
+   * Fetch interaction information for a specific ligand instance.
+   *
+   * Retrieves non-covalent contacts between a ligand and surrounding
+   * residues in a PDB entry.
+   *
+   * @param {string} pdbId - The 4-character PDB ID.
+   * @param {string} chainId - Chain identifier for the ligand.
+   * @param {string|number} residueNo - Residue number of the ligand instance.
+   * @returns {Promise<Object>} Interaction data from PDBe.
+   */
+  static getLigandInteractions(pdbId, chainId, residueNo) {
+    return this.fetchJson(
+      `${PD_BE_INTERACTIONS_BASE_URL}/${pdbId}/${chainId}/${residueNo}`
+    );
   }
 
   /**

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -7,6 +7,7 @@ export const RCSB_ENTRY_BASE_URL = 'https://data.rcsb.org/rest/v1/core/entry';
 export const PD_BE_SUMMARY_BASE_URL = 'https://www.ebi.ac.uk/pdbe/graph-api/pdb/summary';
 export const RCSB_PDB_DOWNLOAD_BASE_URL = 'https://files.rcsb.org/download';
 export const PD_BE_LIGAND_MONOMERS_BASE_URL = 'https://www.ebi.ac.uk/pdbe/api/pdb/entry/ligand_monomers';
+export const PD_BE_INTERACTIONS_BASE_URL = 'https://www.ebi.ac.uk/pdbe/api/pdb/entry/ligand_interactions';
 export const RCSB_GROUP_BASE_URL = 'https://data.rcsb.org/rest/v1/core/entry_groups';
 export const PUBCHEM_COMPOUND_BASE_URL = 'https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound';
 export const PUBCHEM_COMPOUND_LINK_BASE = 'https://pubchem.ncbi.nlm.nih.gov/compound';


### PR DESCRIPTION
## Summary
- add PDBe ligand interaction base URL constant
- fetch ligand interaction data and render connectors in ligand details modal
- allow toggling interaction overlays

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ff890ee48832988a49c4452e19144