### PR TITLE
feat: show ligand environment in instance viewer

### DIFF
--- a/src/modal/LigandDetails.js
+++ b/src/modal/LigandDetails.js
@@ -69,13 +69,28 @@ class LigandDetails {
                                 height: '100%'
                             });
                             viewer.addModel(pdbData, 'pdb');
-                            viewer.setStyle({}, { cartoon: { color: 'spectrum' } });
-                            const selection = {
+                            // Show overall protein as light grey cartoon
+                            viewer.setStyle({}, { cartoon: { color: 'lightgrey' } });
+                            const ligandSel = {
                                 chain: molecule.labelAsymId,
                                 resi: parseInt(molecule.authSeqId, 10)
                             };
-                            viewer.setStyle(selection, { stick: { radius: 0.25, colorscheme: 'greenCarbon' } });
-                            viewer.zoomTo(selection);
+                            const pocketSel = { within: { distance: 5, sel: ligandSel } };
+                            // Surrounding residues as element-coloured sticks
+                            viewer.setStyle(pocketSel, {
+                                stick: { radius: 0.15, colorscheme: 'element' }
+                            });
+                            // Ligand in ball-and-stick with element colouring
+                            viewer.setStyle(ligandSel, {
+                                stick: { radius: 0.2, colorscheme: 'element' },
+                                sphere: { scale: 0.3, colorscheme: 'element' }
+                            });
+                            // Transparent surface around binding pocket
+                            viewer.addSurface($3Dmol.SurfaceType.MS,
+                                { opacity: 0.6, color: 'white' },
+                                pocketSel
+                            );
+                            viewer.zoomTo(ligandSel);
                             viewer.render();
                             this.viewer = viewer;
                         } catch (e) {
@@ -97,7 +112,10 @@ class LigandDetails {
                         height: '100%'
                     });
                     viewer.addModel(sdfData, 'sdf');
-                    viewer.setStyle({}, { stick: { radius: 0.2 }, sphere: { scale: 0.3 } });
+                    viewer.setStyle({}, {
+                        stick: { radius: 0.2, colorscheme: 'element' },
+                        sphere: { scale: 0.3, colorscheme: 'element' }
+                    });
                     viewer.setStyle({ elem: 'H' }, {});
                     viewer.zoomTo();
                     viewer.render();

--- a/tests/ligandDetails.test.js
+++ b/tests/ligandDetails.test.js
@@ -60,12 +60,13 @@ describe('LigandDetails viewer focus', () => {
     const viewer = {
       addModel: mock.fn(),
       setStyle: mock.fn(),
+      addSurface: mock.fn(),
       zoomTo: mock.fn(),
       render: mock.fn(),
       clear: () => {},
       destroy: () => {}
     };
-    global.$3Dmol = { createViewer: mock.fn(() => viewer) };
+    global.$3Dmol = { createViewer: mock.fn(() => viewer), SurfaceType: { MS: 'MS' } };
     mock.method(global, 'setTimeout', (fn) => { fn(); });
 
     const ld = new LigandDetails(moleculeManager);
@@ -76,6 +77,9 @@ describe('LigandDetails viewer focus', () => {
     assert.deepStrictEqual(ApiService.getPdbFile.mock.calls[0].arguments, ['1abc']);
     assert.strictEqual(viewer.zoomTo.mock.callCount(), 1);
     assert.deepStrictEqual(viewer.zoomTo.mock.calls[0].arguments, [{ chain: 'B', resi: 5 }]);
+    assert.strictEqual(viewer.addSurface.mock.callCount(), 1);
+    assert.strictEqual(viewer.addSurface.mock.calls[0].arguments[0], 'MS');
+    assert.deepStrictEqual(viewer.setStyle.mock.calls[0].arguments, [{}, { cartoon: { color: 'lightgrey' } }]);
 
     mock.restoreAll();
     delete global.$3Dmol;


### PR DESCRIPTION
## Summary
- render protein as light grey cartoon
- highlight ligand in ball-and-stick with element colours
- add transparent pocket surface and surrounding residue sticks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ff8e1143483299db8f5947861cc21