### PR TITLE
feat: integrate RDKit WebAssembly with removable Joy demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "molexplorer",
       "version": "0.0.0",
       "dependencies": {
-        "smiles-drawer": "^2.0.1"
+        "@rdkit/rdkit": "^2025.3.4-1.0.0"
       },
       "devDependencies": {
         "vite": "^5.2.0"
@@ -405,6 +405,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/@rdkit/rdkit": {
+      "version": "2025.3.4-1.0.0",
+      "resolved": "https://registry.npmjs.org/@rdkit/rdkit/-/rdkit-2025.3.4-1.0.0.tgz",
+      "integrity": "sha512-MJzNoeW2SWt2KCdIibfY213uLWyHZjFfS2ntJ/HuYNHdu6dEiim7jb6ZMU9wnt9Oovkc85BHMuupxkufIMvftQ==",
+      "license": "BSD-3-Clause",
+      "workspaces": [
+        "examples/react",
+        "examples/javascript",
+        "examples/vue",
+        "examples/angular",
+        "examples/nextjs",
+        "examples/node"
+      ]
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.46.2.tgz",
@@ -692,12 +706,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/chroma-js": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.6.0.tgz",
-      "integrity": "sha512-BLHvCB9s8Z1EV4ethr6xnkl/P2YRFOGqfgvuMG/MyCbZPrTA+NeiByY6XvgF0zP4/2deU2CXnWyMa3zu1LqQ3A==",
-      "license": "(BSD-3-Clause AND Apache-2.0)"
-    },
     "node_modules/esbuild": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
@@ -845,15 +853,6 @@
         "@rollup/rollup-win32-ia32-msvc": "4.46.2",
         "@rollup/rollup-win32-x64-msvc": "4.46.2",
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/smiles-drawer": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/smiles-drawer/-/smiles-drawer-2.1.7.tgz",
-      "integrity": "sha512-gApm5tsWrAYDkjbGYQb5OhwIyHvtM2kIO40DfATaOV0DPm0wA63yn4Ow7us27BT49lDdU9busCOPN9fpyonzaA==",
-      "license": "MIT",
-      "dependencies": {
-        "chroma-js": "^2.4.2"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -12,5 +12,7 @@
   "devDependencies": {
     "vite": "^5.2.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "@rdkit/rdkit": "^2025.3.4-1.0.0"
+  }
 }

--- a/src/joy.js
+++ b/src/joy.js
@@ -1,0 +1,22 @@
+import { getRDKit } from './utils/rdkit.js';
+
+export async function initJoy() {
+    const rdkit = await getRDKit();
+    const button = document.createElement('button');
+    button.id = 'joy-btn';
+    button.textContent = 'Joy';
+    Object.assign(button.style, {
+        position: 'fixed',
+        bottom: '20px',
+        left: '20px',
+        zIndex: 1002
+    });
+
+    button.addEventListener('click', () => {
+        const mol = rdkit.get_mol('c1ccccc1');
+        alert(mol.get_smiles());
+        mol.delete();
+    });
+
+    document.body.appendChild(button);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ import PdbDetailsModal from './modal/PdbDetailsModal.js';
 import AddMoleculeModal from './modal/AddMoleculeModal.js';
 import ProteinBrowser from './components/ProteinBrowser.js';
 import ComparisonModal from './modal/ComparisonModal.js';
+import { initJoy } from './joy.js';
 
 class MoleculeManager {
     constructor() {
@@ -263,6 +264,8 @@ function showNotification(message, type = 'info') {
         }, 300);
     }, 3000);
 }
+
+initJoy();
 
 window.moleculeManager = moleculeManager;
 window.fragmentLibrary = fragmentLibrary;

--- a/src/utils/rdkit.js
+++ b/src/utils/rdkit.js
@@ -1,0 +1,10 @@
+import initRDKit from '@rdkit/rdkit';
+
+let rdkitModule = null;
+
+export async function getRDKit() {
+    if (!rdkitModule) {
+        rdkitModule = await initRDKit();
+    }
+    return rdkitModule;
+}


### PR DESCRIPTION
## Summary
- add `@rdkit/rdkit` dependency and loader utility
- introduce a removable Joy button demonstrating RDKit usage
- hook Joy demo into main initialization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ff98694d08329957e13ab1627860c