### PR TITLE
feat: add dark mode theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
 
     <!-- Main App Content -->
     <header>
+        <button id="theme-toggle" class="theme-toggle" title="Toggle dark mode">🌙</button>
         <h1>ChemLogic Interface</h1>
         <p>Molecular Data Visualization and Pattern Analysis</p>
         <p class="author">By Charlie Harris 🛡️</p>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ChemLogic Interface</title>
     <link rel="stylesheet" href="style.css" />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 
 <body>
@@ -34,7 +35,9 @@
 
     <!-- Main App Content -->
     <header>
-        <button id="theme-toggle" class="theme-toggle" title="Toggle dark mode">🌙</button>
+        <button id="theme-toggle" class="theme-toggle" title="Toggle dark mode">
+            <span id="theme-toggle-icon" class="material-icons">dark_mode</span>
+        </button>
         <h1>ChemLogic Interface</h1>
         <p>Molecular Data Visualization and Pattern Analysis</p>
         <p class="author">By Charlie Harris 🛡️</p>

--- a/src/components/MoleculeCard.js
+++ b/src/components/MoleculeCard.js
@@ -146,7 +146,9 @@ class MoleculeCard {
 
         setTimeout(() => {
             try {
-                const viewer = $3Dmol.createViewer(viewerContainer, { backgroundColor: 'white' });
+                const bgColor = document.body?.classList?.contains('dark-mode') ? '#e0e0e0' : 'white';
+                const viewer = $3Dmol.createViewer(viewerContainer, { backgroundColor: bgColor });
+                viewerContainer.viewer = viewer;
                 viewer.addModel(data, format);
                 viewer.setStyle({}, { stick: {} });
                 viewer.setStyle({ elem: 'H' }, {});

--- a/src/main.js
+++ b/src/main.js
@@ -268,3 +268,30 @@ window.moleculeManager = moleculeManager;
 window.fragmentLibrary = fragmentLibrary;
 window.proteinBrowser = proteinBrowser;
 window.showNotification = showNotification;
+
+function toggleDarkMode() {
+    document.body.classList.toggle('dark-mode');
+    const isDark = document.body.classList.contains('dark-mode');
+    const bg = isDark ? '#e0e0e0' : 'white';
+    document.querySelectorAll('.viewer-container, .molecule-viewer, .details-viewer').forEach(el => {
+        if (el.viewer && typeof el.viewer.setBackgroundColor === 'function') {
+            el.viewer.setBackgroundColor(bg);
+            el.viewer.render();
+        } else {
+            el.style.background = bg;
+        }
+    });
+    const btn = document.getElementById('theme-toggle');
+    if (btn) {
+        btn.textContent = isDark ? '☀️' : '🌙';
+    }
+}
+
+function initThemeToggle() {
+    const btn = document.getElementById('theme-toggle');
+    if (btn) {
+        btn.addEventListener('click', toggleDarkMode);
+    }
+}
+
+initThemeToggle();

--- a/src/main.js
+++ b/src/main.js
@@ -281,9 +281,9 @@ function toggleDarkMode() {
             el.style.background = bg;
         }
     });
-    const btn = document.getElementById('theme-toggle');
-    if (btn) {
-        btn.textContent = isDark ? '☀️' : '🌙';
+    const icon = document.getElementById('theme-toggle-icon');
+    if (icon) {
+        icon.textContent = isDark ? 'light_mode' : 'dark_mode';
     }
 }
 

--- a/src/modal/ComparisonModal.js
+++ b/src/modal/ComparisonModal.js
@@ -27,7 +27,9 @@ class ComparisonModal {
         }
         setTimeout(() => {
             try {
-                const viewer = $3Dmol.createViewer(this.viewerContainer, { backgroundColor: 'white' });
+                const bgColor = document.body?.classList?.contains('dark-mode') ? '#e0e0e0' : 'white';
+                const viewer = $3Dmol.createViewer(this.viewerContainer, { backgroundColor: bgColor });
+                this.viewerContainer.viewer = viewer;
                 const model1 = viewer.addModel(molA.sdf, 'sdf');
                 const model2 = viewer.addModel(molB.sdf, 'sdf');
                 model1.setStyle({}, { stick: { colorscheme: 'cyanCarbon' } });

--- a/src/modal/LigandDetails.js
+++ b/src/modal/LigandDetails.js
@@ -63,11 +63,13 @@ class LigandDetails {
                 .then(pdbData => {
                     setTimeout(() => {
                         try {
+                            const bgColor = document.body?.classList?.contains('dark-mode') ? '#e0e0e0' : 'white';
                             const viewer = $3Dmol.createViewer(this.detailsViewer, {
-                                backgroundColor: 'white',
+                                backgroundColor: bgColor,
                                 width: '100%',
                                 height: '100%'
                             });
+                            this.detailsViewer.viewer = viewer;
                             viewer.addModel(pdbData, 'pdb');
                             viewer.setStyle({}, { cartoon: { color: 'spectrum' } });
                             const selection = {
@@ -91,11 +93,13 @@ class LigandDetails {
         } else if (sdfData) {
             setTimeout(() => {
                 try {
+                    const bgColor = document.body?.classList?.contains('dark-mode') ? '#e0e0e0' : 'white';
                     const viewer = $3Dmol.createViewer(this.detailsViewer, {
-                        backgroundColor: 'white',
+                        backgroundColor: bgColor,
                         width: '100%',
                         height: '100%'
                     });
+                    this.detailsViewer.viewer = viewer;
                     viewer.addModel(sdfData, 'sdf');
                     viewer.setStyle({}, { stick: { radius: 0.2 }, sphere: { scale: 0.3 } });
                     viewer.setStyle({ elem: 'H' }, {});
@@ -157,6 +161,7 @@ class LigandDetails {
         }
         if (this.detailsViewer) {
             this.detailsViewer.innerHTML = '';
+            this.detailsViewer.viewer = null;
         }
     }
 }

--- a/src/modal/PdbDetailsModal.js
+++ b/src/modal/PdbDetailsModal.js
@@ -61,11 +61,13 @@ class PdbDetailsModal {
 
             setTimeout(() => {
                 try {
+                    const bgColor = document.body?.classList?.contains('dark-mode') ? '#e0e0e0' : 'white';
                     const viewer = $3Dmol.createViewer(viewerContainer, {
-                        backgroundColor: 'white',
+                        backgroundColor: bgColor,
                         width: '100%',
                         height: '100%'
                     });
+                    viewerContainer.viewer = viewer;
                     viewer.addModel(pdbData, 'pdb');
                     viewer.setStyle({}, { cartoon: { color: 'spectrum' } });
                     viewer.zoomTo();

--- a/style.css
+++ b/style.css
@@ -1643,3 +1643,76 @@ main {
         width: 100%;
     }
 }
+
+/* Theme toggle button */
+.theme-toggle {
+    position: absolute;
+    top: 15px;
+    left: 20px;
+    background: transparent;
+    border: none;
+    color: white;
+    font-size: 20px;
+    cursor: pointer;
+}
+
+/* Dark mode styles */
+body.dark-mode {
+    background-color: #121212;
+    color: #eee;
+}
+
+body.dark-mode header {
+    background: linear-gradient(90deg, #333 0%, #555 100%);
+}
+
+body.dark-mode .theme-toggle {
+    color: #ffd54f;
+}
+
+body.dark-mode .tabs {
+    border-bottom-color: #444;
+}
+
+body.dark-mode .tab-button {
+    color: #bbb;
+}
+
+body.dark-mode .tab-button.active {
+    color: #fff;
+}
+
+body.dark-mode .tab-button.active::after {
+    background-color: #fff;
+}
+
+body.dark-mode .fragment-controls,
+body.dark-mode .protein-controls {
+    background-color: #2c2c2c;
+}
+
+body.dark-mode .database-header h2 {
+    color: #eee;
+}
+
+body.dark-mode .molecule-card {
+    background: #1e1e1e;
+    border-color: #444;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+}
+
+body.dark-mode .molecule-card h3 {
+    color: #88d3ce;
+}
+
+body.dark-mode .molecule-card .formula,
+body.dark-mode .molecule-card .info,
+body.dark-mode .molecule-card p {
+    color: #ccc;
+}
+
+body.dark-mode .viewer-container,
+body.dark-mode .molecule-viewer,
+body.dark-mode .details-viewer {
+    background: #e0e0e0;
+}

--- a/style.css
+++ b/style.css
@@ -1652,8 +1652,11 @@ main {
     background: transparent;
     border: none;
     color: white;
-    font-size: 20px;
     cursor: pointer;
+}
+
+.theme-toggle .material-icons {
+    font-size: 24px;
 }
 
 /* Dark mode styles */
@@ -1696,8 +1699,8 @@ body.dark-mode .database-header h2 {
 }
 
 body.dark-mode .molecule-card {
-    background: #1e1e1e;
-    border-color: #444;
+    background: #151515;
+    border-color: #333;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
 }
 

--- a/tests/domStub.js
+++ b/tests/domStub.js
@@ -9,6 +9,12 @@ class Element {
     this.checked = false;
     this.disabled = false;
     this.dataset = {};
+    this.classList = {
+      classes: new Set(),
+      add: (...cls) => cls.forEach(c => this.classList.classes.add(c)),
+      remove: (...cls) => cls.forEach(c => this.classList.classes.delete(c)),
+      contains: (c) => this.classList.classes.has(c)
+    };
   }
   appendChild(child) {
     if (child && child.isFragment) {


### PR DESCRIPTION
## Summary
- add moon icon toggle button to enable dark mode
- style interface and 3D viewers for dark theme
- add theme toggle utilities and test support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ffada0b488329beafe75095f3ce4a