### PR TITLE
feat: add interaction filtering with counts

### DIFF
--- a/index.html
+++ b/index.html
@@ -303,6 +303,25 @@
                     </div>
                 </div>
 
+                <div id="interaction-summary-section" class="details-section">
+                    <div class="section-header">
+                        <h4>Interaction Summary</h4>
+                        <div id="interaction-type-filters" class="interaction-filters"></div>
+                    </div>
+                    <div id="interaction-counts" class="interaction-counts"></div>
+                    <table id="interaction-summary-table" class="pdb-entries-table" style="display: none;">
+                        <thead>
+                            <tr>
+                                <th>Type</th>
+                                <th>Partner</th>
+                                <th>Details</th>
+                            </tr>
+                        </thead>
+                        <tbody id="interaction-summary-body"></tbody>
+                    </table>
+                    <div id="no-interaction-data" style="display: none;">No interaction data available.</div>
+                </div>
+
                 <div class="details-section">
                     <div class="section-header">
                         <h4>Similar Ligands</h4>

--- a/src/modal/LigandDetails.js
+++ b/src/modal/LigandDetails.js
@@ -15,6 +15,13 @@ class LigandDetails {
         this.detailsResidue = document.getElementById('details-residue');
         this.detailsViewer = document.getElementById('details-viewer-container');
         this.detailsJSON = document.getElementById('details-json');
+        this.interactionTable = document.getElementById('interaction-summary-table');
+        this.interactionTbody = document.getElementById('interaction-summary-body');
+        this.interactionCounts = document.getElementById('interaction-counts');
+        this.interactionFilters = document.getElementById('interaction-type-filters');
+        this.noInteractionData = document.getElementById('no-interaction-data');
+        this.currentInteractions = [];
+        this.selectedInteractionTypes = new Set();
         this.viewer = null;
 
         const closeBtn = document.getElementById('close-details-modal');
@@ -133,7 +140,113 @@ class LigandDetails {
         }
         this.detailsJSON.textContent = JSON.stringify(jsonData, null, 2);
 
+        this.loadInteractions(ccdCode, molecule);
+
         this.modal.style.display = 'block';
+    }
+
+    loadInteractions(ccdCode, molecule) {
+        if (!this.interactionTable || !this.interactionTbody || !this.interactionFilters) return;
+        this.interactionTbody.innerHTML = '';
+        if (this.interactionCounts) this.interactionCounts.textContent = '';
+        if (this.noInteractionData) this.noInteractionData.style.display = 'none';
+        return ApiService.getLigandInteractions(
+            molecule?.pdbId,
+            ccdCode,
+            molecule?.authSeqId,
+            molecule?.labelAsymId
+        )
+            .then(data => {
+                this.currentInteractions = Array.isArray(data) ? data : [];
+                if (this.currentInteractions.length === 0) {
+                    if (this.noInteractionData) this.noInteractionData.style.display = 'block';
+                    this.interactionTable.style.display = 'none';
+                    this.interactionFilters.innerHTML = '';
+                    return;
+                }
+                const types = [...new Set(this.currentInteractions.map(i => i.type))];
+                this.selectedInteractionTypes = new Set(types);
+                this.renderInteractionFilters(types);
+                this.renderInteractions();
+            })
+            .catch(() => {
+                this.currentInteractions = [];
+                if (this.noInteractionData) this.noInteractionData.style.display = 'block';
+                this.interactionTable.style.display = 'none';
+                this.interactionFilters.innerHTML = '';
+            });
+    }
+
+    renderInteractionFilters(types) {
+        if (!this.interactionFilters) return;
+        this.interactionFilters.innerHTML = '';
+        types.forEach(type => {
+            const label = document.createElement('label');
+            const cb = document.createElement('input');
+            cb.type = 'checkbox';
+            cb.value = type;
+            cb.checked = true;
+            cb.addEventListener('change', () => {
+                if (cb.checked) {
+                    this.selectedInteractionTypes.add(type);
+                } else {
+                    this.selectedInteractionTypes.delete(type);
+                }
+                this.renderInteractions();
+            });
+            label.appendChild(cb);
+            const text = document.createElement('span');
+            text.textContent = ' ' + this.formatInteractionType(type);
+            label.appendChild(text);
+            this.interactionFilters.appendChild(label);
+        });
+    }
+
+    renderInteractions() {
+        if (!this.interactionTbody) return;
+        const filtered = this.currentInteractions.filter(i => this.selectedInteractionTypes.has(i.type));
+        this.interactionTbody.innerHTML = '';
+        filtered.forEach(inter => {
+            const row = document.createElement('tr');
+            const typeCell = document.createElement('td');
+            typeCell.textContent = this.formatInteractionType(inter.type);
+            const partnerCell = document.createElement('td');
+            partnerCell.textContent = inter.partner || inter.residue || inter.target || '-';
+            const detailsCell = document.createElement('td');
+            if (inter.details) {
+                detailsCell.textContent = inter.details;
+            } else if (typeof inter.distance === 'number') {
+                detailsCell.textContent = `${inter.distance.toFixed(2)} Å`;
+            } else {
+                detailsCell.textContent = '-';
+            }
+            row.appendChild(typeCell);
+            row.appendChild(partnerCell);
+            row.appendChild(detailsCell);
+            this.interactionTbody.appendChild(row);
+        });
+
+        const counts = {};
+        filtered.forEach(i => {
+            counts[i.type] = (counts[i.type] || 0) + 1;
+        });
+        const countsText = Object.entries(counts)
+            .map(([t, c]) => `${c} ${this.formatInteractionType(t)}`)
+            .join(', ');
+        if (this.interactionCounts) {
+            this.interactionCounts.textContent = countsText;
+        }
+        if (filtered.length === 0) {
+            if (this.noInteractionData) this.noInteractionData.style.display = 'block';
+            this.interactionTable.style.display = 'none';
+        } else {
+            if (this.noInteractionData) this.noInteractionData.style.display = 'none';
+            this.interactionTable.style.display = 'table';
+        }
+    }
+
+    formatInteractionType(type) {
+        return type ? type.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase()) : '';
     }
 
     close() {

--- a/src/utils/apiService.js
+++ b/src/utils/apiService.js
@@ -289,6 +289,26 @@ export default class ApiService {
   }
 
   /**
+   * Fetch interaction summary data for a ligand.
+   *
+   * Currently a placeholder that returns an empty array. Implementations can
+   * replace this with calls to a real interaction service.
+   *
+   * @param {string} pdbId - PDB identifier, optional.
+   * @param {string} ccdCode - Ligand chemical component ID.
+   * @param {string} authSeqId - Residue number for bound ligands.
+   * @param {string} labelAsymId - Chain identifier for bound ligands.
+   * @returns {Promise<Array>} Array of interaction objects.
+   */
+  static async getLigandInteractions(pdbId, ccdCode, authSeqId, labelAsymId) {
+    void pdbId;
+    void ccdCode;
+    void authSeqId;
+    void labelAsymId;
+    return [];
+  }
+
+  /**
    * Fetch compound synonyms from PubChem.
    *
    * @param {string} name - Compound name or identifier.

--- a/style.css
+++ b/style.css
@@ -1608,6 +1608,15 @@ main {
     }
 }
 
+.interaction-filters label {
+    margin-right: 10px;
+}
+
+.interaction-counts {
+    margin-bottom: 8px;
+    font-weight: bold;
+}
+
 /* General mobile layout adjustments */
 @media (max-width: 600px) {
     header {

--- a/tests/ligandDetails.test.js
+++ b/tests/ligandDetails.test.js
@@ -83,3 +83,63 @@ describe('LigandDetails viewer focus', () => {
     delete global.window;
   });
 });
+
+describe('LigandDetails interaction filters', () => {
+  it('renders and filters interactions by type', async () => {
+    const dom = new JSDOM();
+    const { document } = dom.window;
+
+    const reg = (id, el = document.createElement('div')) => {
+      el.style = {};
+      document.registerElement(id, el);
+      return el;
+    };
+
+    reg('molecule-details-modal');
+    reg('details-title');
+    reg('details-code');
+    reg('details-source');
+    reg('details-type');
+    reg('details-structure');
+    reg('details-viewer-container');
+    reg('details-json');
+    reg('details-pdb-id');
+    reg('details-chain');
+    reg('details-residue');
+
+    const filtersEl = reg('interaction-type-filters');
+    const countsEl = reg('interaction-counts');
+    const tableEl = reg('interaction-summary-table', document.createElement('table'));
+    const tbodyEl = document.createElement('tbody');
+    document.registerElement('interaction-summary-body', tbodyEl);
+    tableEl.appendChild(tbodyEl);
+    reg('no-interaction-data');
+
+    global.document = document;
+    global.window = { addEventListener: () => {} };
+    document.querySelectorAll = () => [];
+
+    const interactions = [
+      { type: 'hbond', residue: 'A45', distance: 2.7 },
+      { type: 'hydrophobic', residue: 'B12', distance: 3.5 },
+      { type: 'hbond', residue: 'A46', distance: 2.8 }
+    ];
+    mock.method(ApiService, 'getLigandInteractions', async () => interactions);
+
+    const ld = new LigandDetails({ getMolecule: () => ({}) });
+    await ld.loadInteractions('AAA', {});
+
+    assert.strictEqual(tbodyEl.children.length, 3);
+    assert.ok(countsEl.textContent.includes('2 Hbond'));
+
+    ld.selectedInteractionTypes = new Set(['hydrophobic']);
+    ld.renderInteractions();
+
+    assert.strictEqual(tbodyEl.children.length, 1);
+    assert.strictEqual(countsEl.textContent, '1 Hydrophobic');
+
+    mock.restoreAll();
+    delete global.document;
+    delete global.window;
+  });
+});


### PR DESCRIPTION
## Summary
- introduce interaction summary section with per-type filters
- compute aggregated interaction counts and support filtering in `LigandDetails`
- add placeholder API for future interaction data and associated tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ff8a725a483298f70ec008a533a53