### PR TITLE
Add UHV PDB instance to default ligand list

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 import MoleculeLoader from './utils/MoleculeLoader.js';
 import MoleculeRepository from './utils/MoleculeRepository.js';
-import { DEFAULT_MOLECULE_CODES } from './utils/constants.js';
+import { DEFAULT_MOLECULE_CODES, DEFAULT_PDB_INSTANCES } from './utils/constants.js';
 import BoundLigandTable from './components/BoundLigandTable.js';
 import FragmentLibrary from './components/FragmentLibrary.js';
 import LigandModal from './modal/LigandModal.js';
@@ -12,9 +12,10 @@ import ComparisonModal from './modal/ComparisonModal.js';
 
 class MoleculeManager {
     constructor() {
-        this.repository = new MoleculeRepository(
-            DEFAULT_MOLECULE_CODES.map(code => ({ code, status: 'pending' }))
-        );
+        this.repository = new MoleculeRepository([
+            ...DEFAULT_MOLECULE_CODES.map(code => ({ code, status: 'pending' })),
+            ...DEFAULT_PDB_INSTANCES.map(inst => ({ ...inst, status: 'pending' }))
+        ]);
         this.grid = null;
         this.loadingIndicator = null;
         this.cardUI = null;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -29,6 +29,16 @@ export const DEFAULT_MOLECULE_CODES = [
   'J9N',
   'VIA'
 ];
+export const DEFAULT_PDB_INSTANCES = [
+  {
+    code: 'UHV',
+    source: 'reagents',
+    type: 'reagent',
+    pdbId: '5RH5',
+    labelAsymId: 'A',
+    authSeqId: '1001'
+  }
+];
 export const CRYSTALLIZATION_AIDS = [
   'SO4', 'PO4', 'CIT', 'EDO', 'GOL', '1PE',
   'ACE', 'ACT', 'BME', 'DMS', 'FMT', 'IMD', 'MES',


### PR DESCRIPTION
## Summary
- include UHV reagent PDB instance (5RH5 A 1001) in default set
- initialize repository with default PDB instances

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68900409028c8329a2d57e66b6322c59