### PR TITLE
feat(api): add bound ligand interactions endpoint

### DIFF
--- a/src/utils/apiService.js
+++ b/src/utils/apiService.js
@@ -19,6 +19,7 @@ import {
   PD_BE_SUMMARY_BASE_URL,
   RCSB_PDB_DOWNLOAD_BASE_URL,
   PD_BE_LIGAND_MONOMERS_BASE_URL,
+  PD_BE_LIGAND_INTERACTIONS_BASE_URL,
   RCSB_GROUP_BASE_URL,
   PUBCHEM_COMPOUND_BASE_URL,
   PUBCHEM_COMPOUND_LINK_BASE
@@ -286,6 +287,25 @@ export default class ApiService {
    */
   static getLigandMonomers(pdbId) {
     return this.fetchJson(`${PD_BE_LIGAND_MONOMERS_BASE_URL}/${pdbId}`);
+  }
+
+  /**
+   * Fetch interaction data for a specific bound ligand residue.
+   *
+   * Retrieves detailed interactions between a protein residue and its bound
+   * ligand, including interaction types, atoms involved and distances.
+   *
+   * @param {string} pdbId - PDB entry ID (e.g., '1cbs')
+   * @param {string} chainId - Chain identifier (auth_asym_id)
+   * @param {number|string} seqId - Residue sequence number (auth_seq_id)
+   * @returns {Promise<Object>} Interaction data keyed by PDB ID
+   *
+   * @see https://www.ebi.ac.uk/pdbe/graph-api/pdbe_doc/ for interactions API
+   */
+  static getLigandInteractions(pdbId, chainId, seqId) {
+    return this.fetchJson(
+      `${PD_BE_LIGAND_INTERACTIONS_BASE_URL}/${pdbId}/${chainId}/${seqId}`
+    );
   }
 
   /**

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -7,6 +7,7 @@ export const RCSB_ENTRY_BASE_URL = 'https://data.rcsb.org/rest/v1/core/entry';
 export const PD_BE_SUMMARY_BASE_URL = 'https://www.ebi.ac.uk/pdbe/graph-api/pdb/summary';
 export const RCSB_PDB_DOWNLOAD_BASE_URL = 'https://files.rcsb.org/download';
 export const PD_BE_LIGAND_MONOMERS_BASE_URL = 'https://www.ebi.ac.uk/pdbe/api/pdb/entry/ligand_monomers';
+export const PD_BE_LIGAND_INTERACTIONS_BASE_URL = 'https://www.ebi.ac.uk/pdbe/graph-api/pdb/bound_ligand_interactions';
 export const RCSB_GROUP_BASE_URL = 'https://data.rcsb.org/rest/v1/core/entry_groups';
 export const PUBCHEM_COMPOUND_BASE_URL = 'https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound';
 export const PUBCHEM_COMPOUND_LINK_BASE = 'https://pubchem.ncbi.nlm.nih.gov/compound';

--- a/tests/apiService.test.js
+++ b/tests/apiService.test.js
@@ -1,7 +1,7 @@
 import { describe, it, afterEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import ApiService from '../src/utils/apiService.js';
-import { RCSB_LIGAND_BASE_URL, RCSB_MODEL_BASE_URL } from '../src/utils/constants.js';
+import { RCSB_LIGAND_BASE_URL, RCSB_MODEL_BASE_URL, PD_BE_LIGAND_INTERACTIONS_BASE_URL } from '../src/utils/constants.js';
 
 describe('ApiService', () => {
   afterEach(() => {
@@ -66,6 +66,15 @@ describe('ApiService', () => {
       `${RCSB_MODEL_BASE_URL}/1ABC/ligand?auth_seq_id=7&label_asym_id=B&encoding=sdf`
     );
     assert.strictEqual(txt, 'sdf');
+  });
+
+  it('getLigandInteractions builds interaction URL', async () => {
+    global.fetch = mock.fn(async () => ({ ok: true, json: async () => ({}) }));
+    await ApiService.getLigandInteractions('1cbs', 'A', 200);
+    assert.strictEqual(
+      global.fetch.mock.calls[0].arguments[0],
+      `${PD_BE_LIGAND_INTERACTIONS_BASE_URL}/1cbs/A/200`
+    );
   });
 
   it('fetchText caches responses', async () => {


### PR DESCRIPTION
## Summary
- add PDBe bound ligand interactions API constant
- expose `getLigandInteractions` helper in ApiService
- cover interactions endpoint with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890049cff208329b9a7de3beb1bf7a4