### PR TITLE
feat(api): add bound ligand interactions endpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,6 +281,24 @@
                     <div id="ligand-properties" class="properties-panel">Loading properties...</div>
                 </div>
 
+                <div id="interactions-section" class="details-section pdb-instance-field" style="display: none;">
+                    <h4>Residue Interactions</h4>
+                    <table id="interactions-table" class="pdb-entries-table">
+                        <thead>
+                            <tr>
+                                <th>Ligand Atoms</th>
+                                <th>Interaction Type</th>
+                                <th>Protein Residue</th>
+                                <th>Protein Atoms</th>
+                                <th>Details</th>
+                                <th>Distance (Å)</th>
+                            </tr>
+                        </thead>
+                        <tbody id="interactions-tbody"></tbody>
+                    </table>
+                    <p id="no-interactions-message" style="display: none;">No interactions found.</p>
+                </div>
+
                 <div class="details-section">
                     <h4>PDB Entries</h4>
                     <div id="pdb-entries-container">

--- a/src/modal/LigandDetails.js
+++ b/src/modal/LigandDetails.js
@@ -16,6 +16,9 @@ class LigandDetails {
         this.detailsViewer = document.getElementById('details-viewer-container');
         this.detailsJSON = document.getElementById('details-json');
         this.viewer = null;
+        this.interactionsSection = document.getElementById('interactions-section');
+        this.interactionsTbody = document.getElementById('interactions-tbody');
+        this.noInteractionsMessage = document.getElementById('no-interactions-message');
 
         const closeBtn = document.getElementById('close-details-modal');
         if (closeBtn) {
@@ -55,6 +58,16 @@ class LigandDetails {
             if (this.detailsPdbId) this.detailsPdbId.textContent = '-';
             if (this.detailsChain) this.detailsChain.textContent = '-';
             if (this.detailsResidue) this.detailsResidue.textContent = '-';
+        }
+
+        if (this.interactionsSection) {
+            this.interactionsSection.style.display = isInstance ? 'block' : 'none';
+        }
+        if (isInstance) {
+            this.loadInteractions(molecule);
+        } else if (this.interactionsTbody) {
+            this.interactionsTbody.innerHTML = '';
+            if (this.noInteractionsMessage) this.noInteractionsMessage.style.display = 'none';
         }
 
         this.detailsViewer.innerHTML = '<p>Loading structure...</p>';
@@ -152,6 +165,66 @@ class LigandDetails {
         this.detailsJSON.textContent = JSON.stringify(jsonData, null, 2);
 
         this.modal.style.display = 'block';
+    }
+
+    loadInteractions(molecule) {
+        if (!this.interactionsTbody) return;
+        this.interactionsTbody.innerHTML = '';
+        if (this.noInteractionsMessage) {
+            this.noInteractionsMessage.style.display = 'none';
+            this.noInteractionsMessage.textContent = 'No interactions found.';
+        }
+        ApiService.getLigandInteractions(
+            molecule.pdbId,
+            molecule.labelAsymId,
+            molecule.authSeqId
+        )
+            .then(data => {
+                const interactions =
+                    data?.[molecule.pdbId]?.[0]?.interactions ?? [];
+                if (interactions.length === 0) {
+                    if (this.noInteractionsMessage)
+                        this.noInteractionsMessage.style.display = 'block';
+                    return;
+                }
+                for (const interaction of interactions) {
+                    const row = document.createElement('tr');
+                    const ligandAtoms = interaction.ligand_atoms?.join(', ') ?? '-';
+                    const interactionType =
+                        interaction.interaction_type ||
+                        interaction.interaction_class ||
+                        '-';
+                    const residue = interaction.end
+                        ? `${interaction.end.chem_comp_id || ''} ${
+                              interaction.end.author_residue_number || ''
+                          } (${interaction.end.chain_id || ''})`
+                        : '-';
+                    const atomNames =
+                        interaction.end?.atom_names?.join(', ') ?? '-';
+                    const details =
+                        interaction.interaction_details?.join(', ') ?? '-';
+                    const distance =
+                        interaction.distance != null
+                            ? interaction.distance.toFixed(2)
+                            : '-';
+                    row.innerHTML = `
+                        <td>${ligandAtoms}</td>
+                        <td>${interactionType}</td>
+                        <td>${residue}</td>
+                        <td>${atomNames}</td>
+                        <td>${details}</td>
+                        <td>${distance}</td>`;
+                    this.interactionsTbody.appendChild(row);
+                }
+            })
+            .catch(err => {
+                console.error('Error fetching interactions:', err);
+                if (this.noInteractionsMessage) {
+                    this.noInteractionsMessage.textContent =
+                        'Failed to load interactions.';
+                    this.noInteractionsMessage.style.display = 'block';
+                }
+            });
     }
 
     close() {

--- a/src/modal/LigandDetails.js
+++ b/src/modal/LigandDetails.js
@@ -181,7 +181,7 @@ class LigandDetails {
         )
             .then(data => {
                 const interactions =
-                    data?.[molecule.pdbId]?.[0]?.interactions ?? [];
+                    data?.[molecule.pdbId.toLowerCase()]?.[0]?.interactions ?? [];
                 if (interactions.length === 0) {
                     if (this.noInteractionsMessage)
                         this.noInteractionsMessage.style.display = 'block';

--- a/src/utils/apiService.js
+++ b/src/utils/apiService.js
@@ -303,8 +303,9 @@ export default class ApiService {
    * @see https://www.ebi.ac.uk/pdbe/graph-api/pdbe_doc/ for interactions API
    */
   static getLigandInteractions(pdbId, chainId, seqId) {
+    const id = pdbId.toLowerCase();
     return this.fetchJson(
-      `${PD_BE_LIGAND_INTERACTIONS_BASE_URL}/${pdbId}/${chainId}/${seqId}`
+      `${PD_BE_LIGAND_INTERACTIONS_BASE_URL}/${id}/${chainId}/${seqId}`
     );
   }
 

--- a/src/utils/apiService.js
+++ b/src/utils/apiService.js
@@ -19,6 +19,7 @@ import {
   PD_BE_SUMMARY_BASE_URL,
   RCSB_PDB_DOWNLOAD_BASE_URL,
   PD_BE_LIGAND_MONOMERS_BASE_URL,
+  PD_BE_LIGAND_INTERACTIONS_BASE_URL,
   RCSB_GROUP_BASE_URL,
   PUBCHEM_COMPOUND_BASE_URL,
   PUBCHEM_COMPOUND_LINK_BASE
@@ -286,6 +287,25 @@ export default class ApiService {
    */
   static getLigandMonomers(pdbId) {
     return this.fetchJson(`${PD_BE_LIGAND_MONOMERS_BASE_URL}/${pdbId}`);
+  }
+
+  /**
+   * Fetch interaction data for a specific bound ligand residue.
+   *
+   * Retrieves detailed interactions between a protein residue and its bound
+   * ligand, including interaction types, atoms involved and distances.
+   *
+   * @param {string} pdbId - PDB entry ID (e.g., '1cbs')
+   * @param {string} chainId - Chain identifier (auth_asym_id)
+   * @param {number|string} seqId - Residue sequence number (auth_seq_id)
+   * @returns {Promise<Object>} Interaction data keyed by PDB ID
+   *
+   * @see https://www.ebi.ac.uk/pdbe/graph-api/pdbe_doc/ for interactions API
+   */
+  static getLigandInteractions(pdbId, chainId, seqId) {
+    return this.fetchJson(
+      `${PD_BE_LIGAND_INTERACTIONS_BASE_URL}/${pdbId}/${chainId}/${seqId}`
+    );
   }
 
   /**

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -7,6 +7,7 @@ export const RCSB_ENTRY_BASE_URL = 'https://data.rcsb.org/rest/v1/core/entry';
 export const PD_BE_SUMMARY_BASE_URL = 'https://www.ebi.ac.uk/pdbe/graph-api/pdb/summary';
 export const RCSB_PDB_DOWNLOAD_BASE_URL = 'https://files.rcsb.org/download';
 export const PD_BE_LIGAND_MONOMERS_BASE_URL = 'https://www.ebi.ac.uk/pdbe/api/pdb/entry/ligand_monomers';
+export const PD_BE_LIGAND_INTERACTIONS_BASE_URL = 'https://www.ebi.ac.uk/pdbe/graph-api/pdb/bound_ligand_interactions';
 export const RCSB_GROUP_BASE_URL = 'https://data.rcsb.org/rest/v1/core/entry_groups';
 export const PUBCHEM_COMPOUND_BASE_URL = 'https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound';
 export const PUBCHEM_COMPOUND_LINK_BASE = 'https://pubchem.ncbi.nlm.nih.gov/compound';

--- a/tests/apiService.test.js
+++ b/tests/apiService.test.js
@@ -1,7 +1,7 @@
 import { describe, it, afterEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import ApiService from '../src/utils/apiService.js';
-import { RCSB_LIGAND_BASE_URL, RCSB_MODEL_BASE_URL } from '../src/utils/constants.js';
+import { RCSB_LIGAND_BASE_URL, RCSB_MODEL_BASE_URL, PD_BE_LIGAND_INTERACTIONS_BASE_URL } from '../src/utils/constants.js';
 
 describe('ApiService', () => {
   afterEach(() => {
@@ -66,6 +66,15 @@ describe('ApiService', () => {
       `${RCSB_MODEL_BASE_URL}/1ABC/ligand?auth_seq_id=7&label_asym_id=B&encoding=sdf`
     );
     assert.strictEqual(txt, 'sdf');
+  });
+
+  it('getLigandInteractions builds interaction URL', async () => {
+    global.fetch = mock.fn(async () => ({ ok: true, json: async () => ({}) }));
+    await ApiService.getLigandInteractions('1cbs', 'A', 200);
+    assert.strictEqual(
+      global.fetch.mock.calls[0].arguments[0],
+      `${PD_BE_LIGAND_INTERACTIONS_BASE_URL}/1cbs/A/200`
+    );
   });
 
   it('fetchText caches responses', async () => {

--- a/tests/apiService.test.js
+++ b/tests/apiService.test.js
@@ -70,7 +70,7 @@ describe('ApiService', () => {
 
   it('getLigandInteractions builds interaction URL', async () => {
     global.fetch = mock.fn(async () => ({ ok: true, json: async () => ({}) }));
-    await ApiService.getLigandInteractions('1cbs', 'A', 200);
+    await ApiService.getLigandInteractions('1CBS', 'A', 200);
     assert.strictEqual(
       global.fetch.mock.calls[0].arguments[0],
       `${PD_BE_LIGAND_INTERACTIONS_BASE_URL}/1cbs/A/200`


### PR DESCRIPTION
## Summary
- add PDBe bound ligand interactions API constant
- expose `getLigandInteractions` helper in ApiService
- cover interactions endpoint with unit tests
- display residue interactions in ligand details modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890049cff208329b9a7de3beb1bf7a4