### PR TITLE
feat: extend property calculator with additional descriptors

### DIFF
--- a/src/modal/LigandModal.js
+++ b/src/modal/LigandModal.js
@@ -35,6 +35,17 @@ class LigandModal {
                         html += `<div>Molecular Weight: ${weight ?? 'N/A'}</div>`;
                         html += `<div>Formula: ${formula ?? 'N/A'}</div>`;
                     }
+                    if (calcProps) {
+                        if (calcProps.atomCount != null) {
+                            html += `<div>Atom Count: ${calcProps.atomCount}</div>`;
+                        }
+                        if (calcProps.heavyAtomCount != null) {
+                            html += `<div>Heavy Atom Count: ${calcProps.heavyAtomCount}</div>`;
+                        }
+                        if (calcProps.aromaticBondCount != null) {
+                            html += `<div>Aromatic Bond Count: ${calcProps.aromaticBondCount}</div>`;
+                        }
+                    }
                     if (meta?.properties?.IUPACName) {
                         html += `<div>IUPAC Name: ${meta.properties.IUPACName}</div>`;
                     }

--- a/src/utils/propertyCalculator.js
+++ b/src/utils/propertyCalculator.js
@@ -25,9 +25,13 @@ export default class PropertyCalculator {
       }
       const data = await response.json();
       const comp = data?.chem_comp || {};
+      const info = data?.rcsb_chem_comp_info || {};
       return {
         molecularWeight: comp.formula_weight ?? null,
         formula: comp.formula ?? null,
+        atomCount: info.atom_count ?? null,
+        heavyAtomCount: info.atom_count_heavy ?? null,
+        aromaticBondCount: info.bond_count_aromatic ?? null,
       };
     } catch (e) {
       console.error(`Failed to fetch properties for ${ccdCode}:`, e);

--- a/tests/ligandModal.test.js
+++ b/tests/ligandModal.test.js
@@ -57,7 +57,7 @@ describe('LigandModal properties panel', () => {
     mock.method(LigandDetails.prototype, 'show', () => {});
     mock.method(SimilarLigandTable.prototype, 'load', () => {});
     mock.method(PdbEntryList.prototype, 'load', () => {});
-    mock.method(PropertyCalculator, 'getProperties', async () => ({ molecularWeight: 55, formula: 'C2H6O' }));
+    mock.method(PropertyCalculator, 'getProperties', async () => ({ molecularWeight: 55, formula: 'C2H6O', atomCount: 9, heavyAtomCount: 3, aromaticBondCount: 1 }));
     mock.method(ApiService, 'getPubChemMetadata', async () => ({ properties: null, synonyms: [], link: null }));
 
     const lm = new LigandModal({});
@@ -65,6 +65,9 @@ describe('LigandModal properties panel', () => {
     await new Promise(setImmediate);
     assert.ok(propsEl.innerHTML.includes('55'));
     assert.ok(propsEl.innerHTML.includes('C2H6O'));
+    assert.ok(propsEl.innerHTML.includes('Atom Count: 9'));
+    assert.ok(propsEl.innerHTML.includes('Heavy Atom Count: 3'));
+    assert.ok(propsEl.innerHTML.includes('Aromatic Bond Count: 1'));
 
     mock.restoreAll();
     delete global.document;


### PR DESCRIPTION
## Summary
- expand PropertyCalculator to extract atom, heavy atom, and aromatic bond counts
- show new descriptors in LigandModal properties panel
- cover new properties with unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890050e138483299aeefa567ab437cc