### PR TITLE
Improve mobile layout for protein view

### DIFF
--- a/src/components/ProteinBrowser.js
+++ b/src/components/ProteinBrowser.js
@@ -155,13 +155,13 @@ class ProteinBrowser {
                 }
 
                 row.innerHTML = `
-                    <td><img src="${imageUrl}" alt="${pdbId} thumbnail" class="protein-thumbnail"></td>
-                    <td><a href="#" class="pdb-id-link" data-pdb-id="${pdbId}">${pdbId}</a></td>
-                    <td>${title}</td>
-                    <td>${resolution}</td>
-                    <td>${releaseDate}</td>
-                    <td class="bound-ligands-cell">${this.renderBoundLigands(boundLigands, pdbId)}</td>
-                    <td class="view-buttons-cell">
+                    <td data-label="Image"><img src="${imageUrl}" alt="${pdbId} thumbnail" class="protein-thumbnail"></td>
+                    <td data-label="PDB ID"><a href="#" class="pdb-id-link" data-pdb-id="${pdbId}">${pdbId}</a></td>
+                    <td data-label="Title">${title}</td>
+                    <td data-label="Resolution">${resolution}</td>
+                    <td data-label="Release Date">${releaseDate}</td>
+                    <td data-label="Bound Ligands" class="bound-ligands-cell">${this.renderBoundLigands(boundLigands, pdbId)}</td>
+                    <td data-label="View Structure" class="view-buttons-cell">
                         <button class="view-structure-btn rcsb-btn" data-pdb-id="${pdbId}">RCSB PDB</button>
                         <button class="view-structure-btn pdbe-btn" data-pdb-id="${pdbId}">PDBe</button>
                     </td>

--- a/style.css
+++ b/style.css
@@ -829,6 +829,10 @@ main {
     table-layout: fixed;
 }
 
+#protein-results-table-container {
+    overflow-x: auto;
+}
+
 .pdb-entries-table th,
 .pdb-entries-table td {
     padding: 6px 4px;
@@ -897,13 +901,13 @@ main {
 }
 
 #protein-results-table th:nth-child(6) {
-    width: 15%;
-    /* View Structure */
+    width: 30%;
+    /* Bound Ligands */
 }
 
 #protein-results-table th:nth-child(7) {
-    width: 30%;
-    /* Bound Ligands */
+    width: 15%;
+    /* View Structure */
 }
 
 .pdb-entries-table tbody tr:hover {
@@ -1641,6 +1645,50 @@ main {
     .protein-controls input[type="text"],
     .protein-controls button {
         width: 100%;
+    }
+
+    #protein-results-table,
+    #protein-results-table thead,
+    #protein-results-table tbody,
+    #protein-results-table th,
+    #protein-results-table td,
+    #protein-results-table tr {
+        display: block;
+    }
+
+    #protein-results-table thead {
+        display: none;
+    }
+
+    #protein-results-table tr {
+        margin-bottom: 15px;
+        border: 1px solid #e0e0e0;
+        border-radius: 8px;
+        padding: 10px;
+        background-color: #fff;
+    }
+
+    #protein-results-table td {
+        border: none;
+        position: relative;
+        padding-left: 110px;
+        white-space: normal;
+    }
+
+    #protein-results-table td::before {
+        content: attr(data-label);
+        position: absolute;
+        left: 10px;
+        top: 10px;
+        font-weight: 600;
+        width: 100px;
+        white-space: pre-wrap;
+    }
+
+    #protein-results-table .view-buttons-cell {
+        display: flex;
+        gap: 8px;
+        margin-top: 8px;
     }
 }
 


### PR DESCRIPTION
## Summary
- make protein results table responsive for mobile screens
- fix bound ligand/view structure column widths

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689010cd2e1c8329ad42e8265aa698c8