### PR TITLE
Use RDKit to render fragment images

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <title>ChemLogic Interface</title>
     <link rel="stylesheet" href="style.css" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <script src="https://unpkg.com/@rdkit/rdkit/Code/MinimalLib/dist/RDKit_minimal.js"></script>
 </head>
 
 <body>

--- a/src/main.js
+++ b/src/main.js
@@ -217,9 +217,14 @@ class MoleculeManager {
 const moleculeManager = new MoleculeManager().init();
 moleculeManager.loadAllMolecules();
 
+const rdkitPromise =
+    typeof initRDKitModule === 'function'
+        ? initRDKitModule()
+        : Promise.resolve(null);
+
 const fragmentLibrary = new FragmentLibrary(moleculeManager, {
     notify: showNotification,
-    smilesDrawer: window.SmilesDrawer
+    rdkit: rdkitPromise
 }).init();
 fragmentLibrary.loadFragments();
 

--- a/style.css
+++ b/style.css
@@ -1335,6 +1335,21 @@ main {
     border-radius: 4px;
 }
 
+.fragment-card .viewer-container {
+    width: 100%;
+    height: 150px;
+    position: relative;
+    overflow: hidden;
+    border-radius: 8px;
+}
+
+.fragment-card .viewer-container svg {
+    width: 100%;
+    height: 100%;
+    border-radius: 8px;
+    display: block;
+}
+
 .molecule-card .info {
     margin-top: 10px;
     font-size: 12px;

--- a/tests/fragmentLibrary.test.js
+++ b/tests/fragmentLibrary.test.js
@@ -29,8 +29,10 @@ describe('FragmentLibrary', () => {
       addMolecule: () => true,
       showMoleculeDetails: () => {}
     };
-    const smilesStub = { parse: () => {}, Drawer: class { draw() {} } };
-    library = new FragmentLibrary(moleculeManager, { notify: () => {}, smilesDrawer: smilesStub });
+    library = new FragmentLibrary(moleculeManager, {
+      notify: () => {},
+      rdkit: Promise.resolve(null)
+    });
     library.init();
     // Stub createFragmentCard to simplify DOM interactions
     library.createFragmentCard = (fragment) => {


### PR DESCRIPTION
## Summary
- load RDKit minimal library and initialize module in main
- use RDKit to generate fragment SVGs with rounded corners
- update tests for RDKit-based fragment rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68906416dc408329941976746b28b071