### PR TITLE
Use RDKit to render fragment images

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <title>ChemLogic Interface</title>
     <link rel="stylesheet" href="style.css" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <script src="https://unpkg.com/@rdkit/rdkit/Code/MinimalLib/dist/RDKit_minimal.js"></script>
 </head>
 
 <body>

--- a/src/components/FragmentLibrary.js
+++ b/src/components/FragmentLibrary.js
@@ -4,8 +4,7 @@ class FragmentLibrary {
     constructor(moleculeManager, {
         notify = (typeof window !== 'undefined' && window.showNotification)
             || (typeof showNotification === 'function' ? showNotification : () => {}),
-        smilesDrawer = (typeof window !== 'undefined' && window.SmilesDrawer)
-            || (typeof SmilesDrawer !== 'undefined' ? SmilesDrawer : undefined)
+        rdkit = Promise.resolve(null)
     } = {}) {
         this.moleculeManager = moleculeManager;
         this.fragments = [];
@@ -14,7 +13,7 @@ class FragmentLibrary {
         this.sourceFilter = null;
         this.ccdToggle = null;
         this.notify = notify;
-        this.smilesDrawer = smilesDrawer;
+        this.rdkitPromise = rdkit;
     }
 
     init() {
@@ -166,25 +165,22 @@ class FragmentLibrary {
 
         setTimeout(() => {
             if ((fragment.kind === 'SMILES' || fragment.kind === 'SMARTS') && fragment.query) {
-                const canvas = document.createElement('canvas');
-                canvas.width = 200;
-                canvas.height = 150;
-                canvasContainer.appendChild(canvas);
-
-                try {
-                    const sanitizedQuery = this.sanitizeSMILES(fragment.query);
-                    this.smilesDrawer.parse(sanitizedQuery, (tree) => {
-                        const options = { width: 200, height: 150 };
-                        const drawer = new this.smilesDrawer.Drawer(options);
-                        drawer.draw(tree, canvas, 'light', false);
-                    }, (err) => {
-                        console.error('Error parsing SMILES for ' + fragment.name, err);
+                this.rdkitPromise.then((RDKit) => {
+                    if (!RDKit) {
+                        canvasContainer.innerHTML = `<p class="render-error">RDKit not available</p>`;
+                        return;
+                    }
+                    try {
+                        const sanitizedQuery = this.sanitizeSMILES(fragment.query);
+                        const mol = RDKit.get_mol(sanitizedQuery);
+                        const svg = mol.get_svg(200, 150);
+                        mol.delete();
+                        canvasContainer.innerHTML = svg;
+                    } catch (err) {
+                        console.error('Error rendering SMILES for ' + fragment.name, err);
                         canvasContainer.innerHTML = `<p class="render-error">Render error for query: ${fragment.query}</p>`;
-                    });
-                } catch (ex) {
-                    console.error('General error rendering SMILES for ' + fragment.name, ex);
-                    canvasContainer.innerHTML = `<p class="render-error">Render error for query: ${fragment.query}</p>`;
-                }
+                    }
+                });
             } else {
                 canvasContainer.innerHTML = `<p class="render-error">Cannot render type: ${fragment.kind || 'N/A'}</p>`;
             }

--- a/src/main.js
+++ b/src/main.js
@@ -217,9 +217,14 @@ class MoleculeManager {
 const moleculeManager = new MoleculeManager().init();
 moleculeManager.loadAllMolecules();
 
+const rdkitPromise =
+    typeof initRDKitModule === 'function'
+        ? initRDKitModule()
+        : Promise.resolve(null);
+
 const fragmentLibrary = new FragmentLibrary(moleculeManager, {
     notify: showNotification,
-    smilesDrawer: window.SmilesDrawer
+    rdkit: rdkitPromise
 }).init();
 fragmentLibrary.loadFragments();
 

--- a/style.css
+++ b/style.css
@@ -1335,6 +1335,24 @@ main {
     border-radius: 4px;
 }
 
+.fragment-card .viewer-container {
+    width: 100%;
+    height: 150px;
+    position: relative;
+    overflow: hidden;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.fragment-card .viewer-container svg {
+    max-width: 100%;
+    max-height: 100%;
+    border-radius: 8px;
+    display: block;
+}
+
 .molecule-card .info {
     margin-top: 10px;
     font-size: 12px;

--- a/tests/fragmentLibrary.test.js
+++ b/tests/fragmentLibrary.test.js
@@ -29,8 +29,10 @@ describe('FragmentLibrary', () => {
       addMolecule: () => true,
       showMoleculeDetails: () => {}
     };
-    const smilesStub = { parse: () => {}, Drawer: class { draw() {} } };
-    library = new FragmentLibrary(moleculeManager, { notify: () => {}, smilesDrawer: smilesStub });
+    library = new FragmentLibrary(moleculeManager, {
+      notify: () => {},
+      rdkit: Promise.resolve(null)
+    });
     library.init();
     // Stub createFragmentCard to simplify DOM interactions
     library.createFragmentCard = (fragment) => {


### PR DESCRIPTION
## Summary
- load RDKit minimal library and initialize module in main
- use RDKit to generate fragment SVGs with rounded corners
- center RDKit-rendered fragment images within their cards
- update tests for RDKit-based fragment rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68906416dc408329941976746b28b071