### PR TITLE
feat: search proteins by uniprot id

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
                         <option value="G_1002165">NSP15 (Endoribonuclease)</option>
                         <option value="G_1002166">NSP16 (2'-O-Methyltransferase)</option>
                     </select>
-                    <input type="text" id="protein-group-search" placeholder="Enter RCSB Group ID..." value="G_1002155">
+                    <input type="text" id="protein-group-search" placeholder="Enter RCSB Group ID or UniProt ID..." value="G_1002155">
                     <button id="protein-group-search-btn" class="action-btn">Search</button>
                     <div class="toggle-switch">
                         <input type="checkbox" id="hide-aids-toggle" class="toggle-switch-checkbox" checked>

--- a/src/components/ProteinBrowser.js
+++ b/src/components/ProteinBrowser.js
@@ -33,11 +33,11 @@ class ProteinBrowser {
 
         if (this.searchBtn) {
             this.searchBtn.addEventListener('click', () => {
-                const groupId = this.searchInput.value.trim();
-                if (groupId) {
-                    this.fetchProteinGroup(groupId);
+                const queryId = this.searchInput.value.trim();
+                if (queryId) {
+                    this.fetchProteinEntries(queryId);
                 } else {
-                    showNotification('Please enter a Group ID.', 'info');
+                    showNotification('Please enter a Group ID or UniProt ID.', 'info');
                 }
             });
         }
@@ -57,7 +57,7 @@ class ProteinBrowser {
                     if (this.searchInput) {
                         this.searchInput.value = selected;
                     }
-                    this.fetchProteinGroup(selected);
+                    this.fetchProteinEntries(selected);
                 }
             });
         }
@@ -65,23 +65,28 @@ class ProteinBrowser {
         return this;
     }
 
-    async fetchProteinGroup(groupId) {
+    async fetchProteinEntries(identifier) {
         this.loadingIndicator.style.display = 'block';
         this.resultsContainer.style.display = 'none';
         this.noResultsMessage.style.display = 'none';
 
         try {
-            const data = await ApiService.getProteinGroup(groupId);
-            const memberIds = data.rcsb_group_container_identifiers.group_member_ids;
-            this.currentProteinDetails = await this.fetchMemberDetails(memberIds);
+            let pdbIds = [];
+            if (identifier.toUpperCase().startsWith('G_')) {
+                const data = await ApiService.getProteinGroup(identifier);
+                pdbIds = data.rcsb_group_container_identifiers.group_member_ids;
+            } else {
+                pdbIds = await ApiService.getPdbEntriesForUniprot(identifier);
+            }
+            this.currentProteinDetails = await this.fetchMemberDetails(pdbIds);
             this.displayResults(this.currentProteinDetails);
         } catch (error) {
-            console.error('Error fetching protein group:', error);
-            this.noResultsMessage.textContent = 'Could not fetch data for the given Group ID.';
+            console.error('Error fetching protein entries:', error);
+            this.noResultsMessage.textContent = 'Could not fetch data for the given identifier.';
             this.noResultsMessage.style.display = 'block';
             const msg = error.status && error.url
-                ? `Failed to fetch protein group (status ${error.status}) from ${error.url}`
-                : 'Failed to fetch protein group data.';
+                ? `Failed to fetch protein data (status ${error.status}) from ${error.url}`
+                : 'Failed to fetch protein data.';
             if (typeof showNotification === 'function') {
                 showNotification(msg, 'error');
             }

--- a/src/utils/apiService.js
+++ b/src/utils/apiService.js
@@ -20,6 +20,7 @@ import {
   RCSB_PDB_DOWNLOAD_BASE_URL,
   PD_BE_LIGAND_MONOMERS_BASE_URL,
   RCSB_GROUP_BASE_URL,
+  UNIPROT_ENTRY_BASE_URL,
   PUBCHEM_COMPOUND_BASE_URL,
   PUBCHEM_COMPOUND_LINK_BASE
 } from './constants.js';
@@ -333,6 +334,22 @@ export default class ApiService {
       properties,
       link: cid ? `${PUBCHEM_COMPOUND_LINK_BASE}/${cid}` : null
     };
+  }
+
+  /**
+   * Fetch PDB entry IDs linked to a UniProt accession.
+   *
+   * Queries the UniProt REST API for cross-references and extracts all
+   * associated PDB identifiers.
+   *
+   * @param {string} uniprotId - UniProt accession (e.g., 'P0DTC2').
+   * @returns {Promise<string[]>} Array of PDB IDs.
+   */
+  static async getPdbEntriesForUniprot(uniprotId) {
+    const url = `${UNIPROT_ENTRY_BASE_URL}/${uniprotId}.json`;
+    const data = await this.fetchJson(url);
+    const refs = data?.uniProtKBCrossReferences ?? [];
+    return refs.filter(ref => ref.database === 'PDB').map(ref => ref.id);
   }
 
   /**

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -8,6 +8,7 @@ export const PD_BE_SUMMARY_BASE_URL = 'https://www.ebi.ac.uk/pdbe/graph-api/pdb/
 export const RCSB_PDB_DOWNLOAD_BASE_URL = 'https://files.rcsb.org/download';
 export const PD_BE_LIGAND_MONOMERS_BASE_URL = 'https://www.ebi.ac.uk/pdbe/api/pdb/entry/ligand_monomers';
 export const RCSB_GROUP_BASE_URL = 'https://data.rcsb.org/rest/v1/core/entry_groups';
+export const UNIPROT_ENTRY_BASE_URL = 'https://rest.uniprot.org/uniprotkb';
 export const PUBCHEM_COMPOUND_BASE_URL = 'https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound';
 export const PUBCHEM_COMPOUND_LINK_BASE = 'https://pubchem.ncbi.nlm.nih.gov/compound';
 export const PD_BE_STATIC_IMAGE_BASE_URL = 'https://www.ebi.ac.uk/pdbe/static/files/pdbechem_v2';

--- a/tests/apiService.test.js
+++ b/tests/apiService.test.js
@@ -1,7 +1,11 @@
 import { describe, it, afterEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import ApiService from '../src/utils/apiService.js';
-import { RCSB_LIGAND_BASE_URL, RCSB_MODEL_BASE_URL } from '../src/utils/constants.js';
+import {
+  RCSB_LIGAND_BASE_URL,
+  RCSB_MODEL_BASE_URL,
+  UNIPROT_ENTRY_BASE_URL
+} from '../src/utils/constants.js';
 
 describe('ApiService', () => {
   afterEach(() => {
@@ -66,6 +70,22 @@ describe('ApiService', () => {
       `${RCSB_MODEL_BASE_URL}/1ABC/ligand?auth_seq_id=7&label_asym_id=B&encoding=sdf`
     );
     assert.strictEqual(txt, 'sdf');
+  });
+
+  it('getPdbEntriesForUniprot parses PDB ids', async () => {
+    const mockData = {
+      uniProtKBCrossReferences: [
+        { database: 'PDB', id: '1ABC' },
+        { database: 'Other', id: 'XYZ' }
+      ]
+    };
+    global.fetch = mock.fn(async () => ({ ok: true, json: async () => mockData }));
+    const ids = await ApiService.getPdbEntriesForUniprot('P12345');
+    assert.deepStrictEqual(ids, ['1ABC']);
+    assert.strictEqual(
+      global.fetch.mock.calls[0].arguments[0],
+      `${UNIPROT_ENTRY_BASE_URL}/P12345.json`
+    );
   });
 
   it('fetchText caches responses', async () => {


### PR DESCRIPTION
## Summary
- allow searching protein structures by RCSB group or UniProt accession
- fetch PDB IDs from the UniProt API and display their details
- test UniProt lookup for ApiService

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68906bd4be08832985d11b3e1936fc40