### PR TITLE
feat: highlight bound ligands in PDB viewer

### DIFF
--- a/src/modal/PdbDetailsModal.js
+++ b/src/modal/PdbDetailsModal.js
@@ -69,7 +69,12 @@ class PdbDetailsModal {
                     });
                     viewerContainer.viewer = viewer;
                     viewer.addModel(pdbData, 'pdb');
-                    viewer.setStyle({}, { cartoon: { color: 'spectrum' } });
+                    viewer.setStyle({}, { cartoon: { color: '#b3b3b3', opacity: 0.7 } });
+                    // highlight bound ligands with element-based colors using thick sticks
+                    viewer.setStyle({ hetflag: true }, {
+                        stick: { radius: 0.5, colorscheme: 'element' }
+                    });
+                    viewer.setStyle({ hetflag: true, resn: ['HOH', 'H2O', 'WAT'] }, {});
                     viewer.zoomTo();
                     viewer.render();
                 } catch (e) {


### PR DESCRIPTION
## Summary
- highlight bound ligands in 3D PDB model with thick element-colored sticks against muted protein cartoon

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890789fc0e8832989d12f9b66a576f6