### PR TITLE
Add fragment-rich proteins to suggestions

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,6 +112,10 @@
                         <option value="G_1002165">NSP15 (Endoribonuclease)</option>
                         <option value="G_1002166">NSP16 (2'-O-Methyltransferase)</option>
                         <option value="B1MDI3">TrmD (tRNA methyltransferase)</option>
+                        <option value="O60885">BRD4 (Bromodomain-containing protein 4)</option>
+                        <option value="P07900">Hsp90 (Heat Shock Protein 90)</option>
+                        <option value="P00918">Carbonic Anhydrase II</option>
+                        <option value="P24941">CDK2 (Cyclin-Dependent Kinase 2)</option>
                     </select>
                     <input type="text" id="protein-group-search" placeholder="Enter RCSB Group ID or UniProt ID..." value="G_1002155">
                     <button id="protein-group-search-btn" class="action-btn">Search</button>


### PR DESCRIPTION
## Summary
- extend suggested protein dropdown with fragment-screened targets (BRD4, Hsp90, Carbonic Anhydrase II, CDK2)

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890843e4b0c83298aa040792cccbddc