### PR TITLE
Add UniProt similarity search option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ChemLogic Interface is a demo application for exploring molecular structures, fragments and proteins. It combines local fragment libraries with live data from the PDBe and RCSB APIs to provide quick visualisations and analysis.
 
+The protein browser supports UniProt searches with an optional button to include proteins from the same UniRef90 cluster (90% identity / 80% overlap).
+
 ## Requirements
 - Node.js 18 or later
 

--- a/index.html
+++ b/index.html
@@ -115,6 +115,7 @@
                     </select>
                     <input type="text" id="protein-group-search" placeholder="Enter RCSB Group ID or UniProt ID..." value="G_1002155">
                     <button id="protein-group-search-btn" class="action-btn">Search</button>
+                    <button id="protein-group-search-similar-btn" class="action-btn">Search + Similar (90/80%)</button>
                     <div class="toggle-switch">
                         <input type="checkbox" id="hide-aids-toggle" class="toggle-switch-checkbox" checked>
                         <label class="toggle-switch-label" for="hide-aids-toggle"></label>

--- a/src/components/ProteinBrowser.js
+++ b/src/components/ProteinBrowser.js
@@ -11,6 +11,7 @@ class ProteinBrowser {
     constructor(moleculeManager) {
         this.moleculeManager = moleculeManager;
         this.searchBtn = null;
+        this.searchSimilarBtn = null;
         this.searchInput = null;
         this.suggestedDropdown = null;
         this.resultsContainer = null;
@@ -23,6 +24,7 @@ class ProteinBrowser {
 
     init() {
         this.searchBtn = document.getElementById('protein-group-search-btn');
+        this.searchSimilarBtn = document.getElementById('protein-group-search-similar-btn');
         this.searchInput = document.getElementById('protein-group-search');
         this.suggestedDropdown = document.getElementById('suggested-groups-dropdown');
         this.resultsContainer = document.getElementById('protein-results-table-container');
@@ -36,6 +38,17 @@ class ProteinBrowser {
                 const queryId = this.searchInput.value.trim();
                 if (queryId) {
                     this.fetchProteinEntries(queryId);
+                } else {
+                    showNotification('Please enter a Group ID or UniProt ID.', 'info');
+                }
+            });
+        }
+
+        if (this.searchSimilarBtn) {
+            this.searchSimilarBtn.addEventListener('click', () => {
+                const queryId = this.searchInput.value.trim();
+                if (queryId) {
+                    this.fetchProteinEntries(queryId, true);
                 } else {
                     showNotification('Please enter a Group ID or UniProt ID.', 'info');
                 }
@@ -65,7 +78,7 @@ class ProteinBrowser {
         return this;
     }
 
-    async fetchProteinEntries(identifier) {
+    async fetchProteinEntries(identifier, includeSimilar = false) {
         this.loadingIndicator.style.display = 'block';
         this.resultsContainer.style.display = 'none';
         this.noResultsMessage.style.display = 'none';
@@ -76,7 +89,7 @@ class ProteinBrowser {
                 const data = await ApiService.getProteinGroup(identifier);
                 pdbIds = data.rcsb_group_container_identifiers.group_member_ids;
             } else {
-                pdbIds = await ApiService.getPdbEntriesForUniprot(identifier);
+                pdbIds = await ApiService.getPdbEntriesForUniprot(identifier, includeSimilar);
             }
             this.currentProteinDetails = await this.fetchMemberDetails(pdbIds);
             this.displayResults(this.currentProteinDetails);

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -9,6 +9,7 @@ export const RCSB_PDB_DOWNLOAD_BASE_URL = 'https://files.rcsb.org/download';
 export const PD_BE_LIGAND_MONOMERS_BASE_URL = 'https://www.ebi.ac.uk/pdbe/api/pdb/entry/ligand_monomers';
 export const RCSB_GROUP_BASE_URL = 'https://data.rcsb.org/rest/v1/core/entry_groups';
 export const UNIPROT_ENTRY_BASE_URL = 'https://rest.uniprot.org/uniprotkb';
+export const UNIPROT_UNIREF_BASE_URL = 'https://rest.uniprot.org/uniref';
 export const PUBCHEM_COMPOUND_BASE_URL = 'https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound';
 export const PUBCHEM_COMPOUND_LINK_BASE = 'https://pubchem.ncbi.nlm.nih.gov/compound';
 export const PD_BE_STATIC_IMAGE_BASE_URL = 'https://www.ebi.ac.uk/pdbe/static/files/pdbechem_v2';


### PR DESCRIPTION
## Summary
- support UniProt similarity searches by querying UniRef90 clusters
- add UI button to include UniRef90 proteins when searching
- document and test UniRef90 search behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689084684bd48329a444413b6cfaf607