### PR TITLE
Add paginated protein browser results

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,6 +144,8 @@
                             </tbody>
                         </table>
                     </div>
+                    <p id="protein-results-count" style="display: none;"></p>
+                    <button id="protein-load-more" class="action-btn" style="display: none;">Load more</button>
                     <p id="no-protein-results-message" style="display: none;">No results found.</p>
                     <div class="loading-indicator" id="protein-loading-indicator" style="display: none;">Loading protein
                         data...</div>

--- a/tests/proteinBrowser.test.js
+++ b/tests/proteinBrowser.test.js
@@ -1,0 +1,15 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import ProteinBrowser from '../src/components/ProteinBrowser.js';
+import ApiService from '../src/utils/apiService.js';
+
+describe('fetchMemberDetails', () => {
+  it('uses offset and limit to fetch batches of IDs', async () => {
+    const pdbIds = Array.from({ length: 50 }, (_, i) => `ID${i}`);
+    mock.method(ApiService, 'getRcsbEntry', async id => ({ rcsb_id: id }));
+    const browser = new ProteinBrowser({});
+    const result = await browser.fetchMemberDetails(pdbIds, 10, 20);
+    assert.strictEqual(result.length, 10);
+    assert.deepStrictEqual(result.map(r => r.rcsb_id), pdbIds.slice(20, 30));
+  });
+});


### PR DESCRIPTION
## Summary
- Paginate ProteinBrowser results via limit/offset and new Load more button
- Track and display current result count while appending batches
- Test fetchMemberDetails pagination logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890880b258c832991362145f1a2a1ec