### PR TITLE
Add fragment modal workflow and validation

### DIFF
--- a/src/components/FragmentLibrary.js
+++ b/src/components/FragmentLibrary.js
@@ -195,6 +195,14 @@ class FragmentLibrary {
             return false;
         }
 
+        const duplicate = this.fragments.some(
+            f => f.name.toLowerCase() === fragmentData.name.toLowerCase()
+        );
+        if (duplicate) {
+            this.notify(`Fragment "${fragmentData.name}" already exists.`, 'error');
+            return false;
+        }
+
         this.fragments.unshift({
             id: `custom-${Date.now()}`,
             name: fragmentData.name,

--- a/src/main.js
+++ b/src/main.js
@@ -228,6 +228,59 @@ const fragmentLibrary = new FragmentLibrary(moleculeManager, {
 }).init();
 fragmentLibrary.loadFragments();
 
+// Add Fragment Modal handlers
+const addFragmentModal = document.getElementById('add-fragment-modal');
+const addFragmentBtn = document.getElementById('add-fragment-btn');
+const cancelAddFragmentBtn = document.getElementById('cancel-add-fragment-btn');
+const closeFragmentModalBtn = document.getElementById('close-fragment-modal');
+const confirmAddFragmentBtn = document.getElementById('confirm-add-fragment-btn');
+
+const openFragmentModal = () => {
+    if (addFragmentModal) {
+        addFragmentModal.style.display = 'block';
+    }
+};
+
+const closeFragmentModal = () => {
+    if (addFragmentModal) {
+        addFragmentModal.style.display = 'none';
+    }
+};
+
+if (addFragmentBtn) {
+    addFragmentBtn.addEventListener('click', openFragmentModal);
+}
+if (cancelAddFragmentBtn) {
+    cancelAddFragmentBtn.addEventListener('click', closeFragmentModal);
+}
+if (closeFragmentModalBtn) {
+    closeFragmentModalBtn.addEventListener('click', closeFragmentModal);
+}
+if (confirmAddFragmentBtn) {
+    confirmAddFragmentBtn.addEventListener('click', () => {
+        const nameEl = document.getElementById('fragment-name');
+        const queryEl = document.getElementById('fragment-query');
+        const sourceEl = document.getElementById('fragment-source');
+        const descEl = document.getElementById('fragment-description');
+
+        const fragmentData = {
+            name: nameEl ? nameEl.value.trim() : '',
+            query: queryEl ? queryEl.value.trim() : '',
+            source: sourceEl ? sourceEl.value.trim() : '',
+            description: descEl ? descEl.value.trim() : ''
+        };
+
+        const added = fragmentLibrary.addFragment(fragmentData);
+        if (added) {
+            if (nameEl) nameEl.value = '';
+            if (queryEl) queryEl.value = '';
+            if (sourceEl) sourceEl.value = 'custom';
+            if (descEl) descEl.value = '';
+            closeFragmentModal();
+        }
+    });
+}
+
 const proteinBrowser = new ProteinBrowser(moleculeManager).init();
 
 function showNotification(message, type = 'info') {

--- a/tests/fragmentLibrary.test.js
+++ b/tests/fragmentLibrary.test.js
@@ -57,20 +57,39 @@ describe('FragmentLibrary', () => {
     assert.strictEqual(library.fragments[0].name, 'Frag');
   });
 
-  it('addFragment missing name returns false and does not modify list', () => {
+  it('addFragment missing name returns false, notifies, and does not modify list', () => {
     library.fragments = [];
     library.renderFragments = () => {};
+    let msg = '';
+    library.notify = (m) => { msg = m; };
     const result = library.addFragment({ query: 'C' });
     assert.strictEqual(result, false);
     assert.strictEqual(library.fragments.length, 0);
+    assert.match(msg, /name and SMILES\/SMARTS query are required/i);
   });
 
-  it('addFragment missing query returns false and does not modify list', () => {
+  it('addFragment missing query returns false, notifies, and does not modify list', () => {
     library.fragments = [];
     library.renderFragments = () => {};
+    let msg = '';
+    library.notify = (m) => { msg = m; };
     const result = library.addFragment({ name: 'Frag' });
     assert.strictEqual(result, false);
     assert.strictEqual(library.fragments.length, 0);
+    assert.match(msg, /name and SMILES\/SMARTS query are required/i);
+  });
+
+  it('addFragment duplicate name returns false and notifies', () => {
+    library.fragments = [];
+    library.renderFragments = () => {};
+    let msg = '';
+    library.notify = (m) => { msg = m; };
+    const first = library.addFragment({ name: 'Frag', query: 'C' });
+    assert.strictEqual(first, true);
+    const second = library.addFragment({ name: 'Frag', query: 'N' });
+    assert.strictEqual(second, false);
+    assert.strictEqual(library.fragments.length, 1);
+    assert.match(msg, /already exists/i);
   });
 
   it('renderFragments filters by search text, source filter, and CCD toggle', () => {


### PR DESCRIPTION
## Summary
- hook up add-fragment modal to open/close and submit fragment data
- add duplicate name validation for user fragments
- extend fragment library tests for modal-style validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689085a3a9ec8329a7cd2cda15c46f64