### PR TITLE
Add UniProt similarity search dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ChemLogic Interface is a demo application for exploring molecular structures, fragments and proteins. It combines local fragment libraries with live data from the PDBe and RCSB APIs to provide quick visualisations and analysis.
 
+The protein browser supports UniProt searches with a dropdown to include proteins from UniRef clusters (e.g., UniRef90 or UniRef50) for similarity-based results.
+
 ## Requirements
 - Node.js 18 or later
 

--- a/index.html
+++ b/index.html
@@ -114,6 +114,11 @@
                         <option value="B1MDI3">TrmD (tRNA methyltransferase)</option>
                     </select>
                     <input type="text" id="protein-group-search" placeholder="Enter RCSB Group ID or UniProt ID..." value="G_1002155">
+                    <select id="protein-similarity-select">
+                        <option value="">Exact only</option>
+                        <option value="UniRef90">+ Similar (90/80%)</option>
+                        <option value="UniRef50">+ Similar (50/80%)</option>
+                    </select>
                     <button id="protein-group-search-btn" class="action-btn">Search</button>
                     <div class="toggle-switch">
                         <input type="checkbox" id="hide-aids-toggle" class="toggle-switch-checkbox" checked>

--- a/src/components/ProteinBrowser.js
+++ b/src/components/ProteinBrowser.js
@@ -12,6 +12,7 @@ class ProteinBrowser {
         this.moleculeManager = moleculeManager;
         this.searchBtn = null;
         this.searchInput = null;
+        this.similaritySelect = null;
         this.suggestedDropdown = null;
         this.resultsContainer = null;
         this.resultsBody = null;
@@ -24,6 +25,7 @@ class ProteinBrowser {
     init() {
         this.searchBtn = document.getElementById('protein-group-search-btn');
         this.searchInput = document.getElementById('protein-group-search');
+        this.similaritySelect = document.getElementById('protein-similarity-select');
         this.suggestedDropdown = document.getElementById('suggested-groups-dropdown');
         this.resultsContainer = document.getElementById('protein-results-table-container');
         this.resultsBody = document.getElementById('protein-results-tbody');
@@ -35,7 +37,8 @@ class ProteinBrowser {
             this.searchBtn.addEventListener('click', () => {
                 const queryId = this.searchInput.value.trim();
                 if (queryId) {
-                    this.fetchProteinEntries(queryId);
+                    const cluster = this.similaritySelect ? this.similaritySelect.value : '';
+                    this.fetchProteinEntries(queryId, cluster);
                 } else {
                     showNotification('Please enter a Group ID or UniProt ID.', 'info');
                 }
@@ -57,7 +60,8 @@ class ProteinBrowser {
                     if (this.searchInput) {
                         this.searchInput.value = selected;
                     }
-                    this.fetchProteinEntries(selected);
+                    const cluster = this.similaritySelect ? this.similaritySelect.value : '';
+                    this.fetchProteinEntries(selected, cluster);
                 }
             });
         }
@@ -65,7 +69,7 @@ class ProteinBrowser {
         return this;
     }
 
-    async fetchProteinEntries(identifier) {
+    async fetchProteinEntries(identifier, cluster = '') {
         this.loadingIndicator.style.display = 'block';
         this.resultsContainer.style.display = 'none';
         this.noResultsMessage.style.display = 'none';
@@ -76,7 +80,7 @@ class ProteinBrowser {
                 const data = await ApiService.getProteinGroup(identifier);
                 pdbIds = data.rcsb_group_container_identifiers.group_member_ids;
             } else {
-                pdbIds = await ApiService.getPdbEntriesForUniprot(identifier);
+                pdbIds = await ApiService.getPdbEntriesForUniprot(identifier, cluster);
             }
             this.currentProteinDetails = await this.fetchMemberDetails(pdbIds);
             this.displayResults(this.currentProteinDetails);

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -9,6 +9,7 @@ export const RCSB_PDB_DOWNLOAD_BASE_URL = 'https://files.rcsb.org/download';
 export const PD_BE_LIGAND_MONOMERS_BASE_URL = 'https://www.ebi.ac.uk/pdbe/api/pdb/entry/ligand_monomers';
 export const RCSB_GROUP_BASE_URL = 'https://data.rcsb.org/rest/v1/core/entry_groups';
 export const UNIPROT_ENTRY_BASE_URL = 'https://rest.uniprot.org/uniprotkb';
+export const UNIPROT_UNIREF_BASE_URL = 'https://rest.uniprot.org/uniref';
 export const PUBCHEM_COMPOUND_BASE_URL = 'https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound';
 export const PUBCHEM_COMPOUND_LINK_BASE = 'https://pubchem.ncbi.nlm.nih.gov/compound';
 export const PD_BE_STATIC_IMAGE_BASE_URL = 'https://www.ebi.ac.uk/pdbe/static/files/pdbechem_v2';

--- a/tests/apiService.test.js
+++ b/tests/apiService.test.js
@@ -4,7 +4,8 @@ import ApiService from '../src/utils/apiService.js';
 import {
   RCSB_LIGAND_BASE_URL,
   RCSB_MODEL_BASE_URL,
-  UNIPROT_ENTRY_BASE_URL
+  UNIPROT_ENTRY_BASE_URL,
+  UNIPROT_UNIREF_BASE_URL
 } from '../src/utils/constants.js';
 
 describe('ApiService', () => {
@@ -96,6 +97,58 @@ describe('ApiService', () => {
       global.fetch.mock.calls[0].arguments[0],
       `${UNIPROT_ENTRY_BASE_URL}/P12345.json`
     );
+  });
+
+  it('getPdbEntriesForUniprot includes UniRef90 members when requested', async () => {
+    const clusterData = {
+      representativeMember: { accessions: ['P12345'] },
+      members: [
+        { accessions: ['Q11111'] },
+        { accessions: ['Q22222'] }
+      ]
+    };
+    const entryData = {
+      P12345: { uniProtKBCrossReferences: [{ database: 'PDB', id: '1AAA' }] },
+      Q11111: { uniProtKBCrossReferences: [{ database: 'PDB', id: '2BBB' }] },
+      Q22222: { uniProtKBCrossReferences: [{ database: 'PDB', id: '3CCC' }] }
+    };
+    global.fetch = mock.fn(async (url) => {
+      if (url === `${UNIPROT_UNIREF_BASE_URL}/UniRef90_P12345.json`) {
+        return { ok: true, json: async () => clusterData };
+      }
+      const match = url.match(/uniprotkb\/(\w+)\.json$/);
+      if (match && entryData[match[1]]) {
+        return { ok: true, json: async () => entryData[match[1]] };
+      }
+      return { ok: false, status: 404 };
+    });
+    const ids = await ApiService.getPdbEntriesForUniprot('P12345', 'UniRef90');
+    assert.deepStrictEqual(ids.sort(), ['1AAA', '2BBB', '3CCC']);
+    assert.strictEqual(global.fetch.mock.callCount(), 4);
+  });
+
+  it('getPdbEntriesForUniprot supports other UniRef clusters', async () => {
+    const clusterData = {
+      representativeMember: { accessions: ['P12345'] },
+      members: [{ accessions: ['Q99999'] }]
+    };
+    const entryData = {
+      P12345: { uniProtKBCrossReferences: [{ database: 'PDB', id: '1AAA' }] },
+      Q99999: { uniProtKBCrossReferences: [{ database: 'PDB', id: '2BBB' }] }
+    };
+    global.fetch = mock.fn(async (url) => {
+      if (url === `${UNIPROT_UNIREF_BASE_URL}/UniRef50_P12345.json`) {
+        return { ok: true, json: async () => clusterData };
+      }
+      const match = url.match(/uniprotkb\/(\w+)\.json$/);
+      if (match && entryData[match[1]]) {
+        return { ok: true, json: async () => entryData[match[1]] };
+      }
+      return { ok: false, status: 404 };
+    });
+    const ids = await ApiService.getPdbEntriesForUniprot('P12345', 'UniRef50');
+    assert.deepStrictEqual(ids.sort(), ['1AAA', '2BBB']);
+    assert.strictEqual(global.fetch.mock.callCount(), 3);
   });
 
   it('fetchText caches responses', async () => {


### PR DESCRIPTION
## Summary
- replace separate button with dropdown to choose UniRef similarity level
- generalize UniProt API helper to accept UniRef cluster options
- expand tests for UniRef cluster inclusion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689084684bd48329a444413b6cfaf607