### PR TITLE
Display publication in protein view

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,6 +135,7 @@
                                     <th>Title</th>
                                     <th>Resolution (Å)</th>
                                     <th>Release Date</th>
+                                    <th>Publication</th>
                                     <th>Bound Ligands</th>
                                     <th>View Structure</th>
                                 </tr>

--- a/src/components/ProteinBrowser.js
+++ b/src/components/ProteinBrowser.js
@@ -215,6 +215,16 @@ class ProteinBrowser {
                 const title = detail.struct?.title || 'N/A';
                 const resolution = detail.rcsb_entry_info?.resolution_combined?.[0]?.toFixed(2) || 'N/A';
                 const releaseDate = detail.rcsb_accession_info?.initial_release_date ? new Date(detail.rcsb_accession_info.initial_release_date).toLocaleDateString() : 'N/A';
+                const citation = detail.rcsb_primary_citation;
+                const citationTitle = citation?.title || 'N/A';
+                const citationUrl = citation?.pdbx_database_id_doi
+                    ? `https://doi.org/${citation.pdbx_database_id_doi}`
+                    : (citation?.pdbx_database_id_PubMed
+                        ? `https://pubmed.ncbi.nlm.nih.gov/${citation.pdbx_database_id_PubMed}/`
+                        : null);
+                const citationHtml = citationUrl
+                    ? `<a href="${citationUrl}" target="_blank">${citationTitle}</a>`
+                    : citationTitle;
                 const imageUrl = `${RCSB_STRUCTURE_IMAGE_BASE_URL}/${pdbId.toLowerCase()}_assembly-1.jpeg`;
 
                 let boundLigands = await this.fetchBoundLigands(pdbId);
@@ -228,6 +238,7 @@ class ProteinBrowser {
                     <td data-label="Title">${title}</td>
                     <td data-label="Resolution">${resolution}</td>
                     <td data-label="Release Date">${releaseDate}</td>
+                    <td data-label="Publication">${citationHtml}</td>
                     <td data-label="Bound Ligands" class="bound-ligands-cell">${this.renderBoundLigands(boundLigands, pdbId)}</td>
                     <td data-label="View Structure" class="view-buttons-cell">
                         <button class="view-structure-btn rcsb-btn" data-pdb-id="${pdbId}">RCSB PDB</button>

--- a/tests/proteinBrowser.test.js
+++ b/tests/proteinBrowser.test.js
@@ -13,3 +13,35 @@ describe('fetchMemberDetails', () => {
     assert.deepStrictEqual(result.map(r => r.rcsb_id), pdbIds.slice(20, 30));
   });
 });
+
+describe('displayResults', () => {
+  it('renders citation link when publication data available', async () => {
+    const rowStub = {
+      innerHTML: '',
+      querySelector: () => ({ addEventListener: () => {}, dataset: {} }),
+      querySelectorAll: () => []
+    };
+    const browser = new ProteinBrowser({});
+    browser.resultsBody = {
+      innerHTML: '',
+      insertRow: () => rowStub
+    };
+    browser.hideAidsToggle = { checked: false };
+    browser.resultsContainer = { style: {} };
+    browser.noResultsMessage = { style: {}, textContent: '' };
+    mock.method(browser, 'fetchBoundLigands', async () => []);
+
+    const details = [{
+      rcsb_id: '1ABC',
+      struct: { title: 'Structure' },
+      rcsb_entry_info: { resolution_combined: [1.5] },
+      rcsb_accession_info: { initial_release_date: '2024-01-01' },
+      rcsb_primary_citation: { title: 'The Paper', pdbx_database_id_doi: '10.1000/xyz' }
+    }];
+
+    await browser.displayResults(details);
+
+    assert.ok(rowStub.innerHTML.includes('The Paper'));
+    assert.ok(rowStub.innerHTML.includes('doi.org/10.1000/xyz'));
+  });
+});


### PR DESCRIPTION
## Summary
- show structure's publication in protein browser table
- render DOI or PubMed link to citation
- test rendering of publication link in protein view

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689095268a848329a26653fadae8e5ad