### PR TITLE
Add ligand instance SDF API and integrate downloads

### DIFF
--- a/src/components/MoleculeCard.js
+++ b/src/components/MoleculeCard.js
@@ -86,7 +86,7 @@ class MoleculeCard {
         `;
     }
 
-    createMoleculeCard(data, ccdCode, format = 'sdf', id = ccdCode) {
+    createMoleculeCard(data, ccdCode, format = 'sdf', id = ccdCode, instanceInfo = null) {
         const card = document.createElement('div');
         card.className = 'molecule-card';
         card.draggable = true;
@@ -114,7 +114,7 @@ class MoleculeCard {
         downloadBtn.title = `Download ${ccdCode} as SDF`;
         downloadBtn.addEventListener('click', e => {
             e.stopPropagation();
-            this.downloadSdf(ccdCode, data);
+            this.downloadSdf(ccdCode, data, instanceInfo);
         });
         card.appendChild(downloadBtn);
 
@@ -251,10 +251,17 @@ class MoleculeCard {
         this.draggedElement = null;
     }
 
-    async downloadSdf(ccdCode, sdfData) {
+    async downloadSdf(ccdCode, sdfData, instanceInfo) {
         try {
             let data = sdfData;
-            if (!data) {
+            let filename = `${ccdCode}.sdf`;
+            if (instanceInfo) {
+                const { pdbId, authSeqId, labelAsymId } = instanceInfo;
+                filename = `${pdbId.toLowerCase()}_${labelAsymId}_${ccdCode}`.toLowerCase() + '.sdf';
+                if (!data) {
+                    data = await ApiService.getInstanceSdf(pdbId, authSeqId, labelAsymId, ccdCode);
+                }
+            } else if (!data) {
                 data = await ApiService.getCcdSdf(ccdCode);
             }
             if (!data) {
@@ -264,7 +271,7 @@ class MoleculeCard {
             const url = URL.createObjectURL(blob);
             const a = document.createElement('a');
             a.href = url;
-            a.download = `${ccdCode}.sdf`;
+            a.download = filename;
             document.body.appendChild(a);
             a.click();
             document.body.removeChild(a);

--- a/src/utils/apiService.js
+++ b/src/utils/apiService.js
@@ -116,12 +116,24 @@ export default class ApiService {
    * @param {string} pdbId - The 4-character PDB ID
    * @param {string|number} authSeqId - Author provided residue/sequence number
    * @param {string} labelAsymId - Chain identifier
+   * @param {string} [compId] - Chemical component ID used in the filename parameter
    * @returns {Promise<string>} SDF file content for the ligand instance
    */
-  static getInstanceSdf(pdbId, authSeqId, labelAsymId) {
-    return this.fetchText(
-      `${RCSB_MODEL_BASE_URL}/${pdbId.toUpperCase()}/ligand?auth_seq_id=${authSeqId}&label_asym_id=${labelAsymId}&encoding=sdf`
-    );
+  static getInstanceSdf(pdbId, authSeqId, labelAsymId, compId) {
+    // Returns a string in the form:
+    // https://models.rcsb.org/v1/4tos/ligand?auth_seq_id=1402&label_asym_id=D&encoding=sdf&filename=4tos_D_355.sdf
+    const pdbIdLower = pdbId.toLowerCase();
+    const params = new URLSearchParams({
+      auth_seq_id: authSeqId,
+      label_asym_id: labelAsymId,
+      encoding: 'sdf',
+    });
+    if (compId) {
+      const filename = `${pdbIdLower}_${labelAsymId}_${compId}`.toLowerCase();
+      params.append('filename', `${filename}.sdf`);
+    }
+    const url = `${RCSB_MODEL_BASE_URL}/${pdbIdLower}/ligand?${params.toString()}`;
+    return this.fetchText(url);
   }
   /**
    * Fetch fragment library data from local TSV file

--- a/tests/apiService.test.js
+++ b/tests/apiService.test.js
@@ -64,12 +64,21 @@ describe('ApiService', () => {
 
   it('getInstanceSdf builds ligand URL', async () => {
     global.fetch = mock.fn(async () => ({ ok: true, text: async () => 'sdf' }));
-    const txt = await ApiService.getInstanceSdf('1abc', 7, 'B');
+    const txt = await ApiService.getInstanceSdf('1ABC', 7, 'B');
     assert.strictEqual(
       global.fetch.mock.calls[0].arguments[0],
-      `${RCSB_MODEL_BASE_URL}/1ABC/ligand?auth_seq_id=7&label_asym_id=B&encoding=sdf`
+      `${RCSB_MODEL_BASE_URL}/1abc/ligand?auth_seq_id=7&label_asym_id=B&encoding=sdf`
     );
     assert.strictEqual(txt, 'sdf');
+  });
+
+  it('getInstanceSdf adds filename when compId supplied', async () => {
+    global.fetch = mock.fn(async () => ({ ok: true, text: async () => 'sdf' }));
+    await ApiService.getInstanceSdf('2XYZ', 10, 'A', 'GLC');
+    assert.strictEqual(
+      global.fetch.mock.calls[0].arguments[0],
+      `${RCSB_MODEL_BASE_URL}/2xyz/ligand?auth_seq_id=10&label_asym_id=A&encoding=sdf&filename=2xyz_a_glc.sdf`
+    );
   });
 
   it('getPdbEntriesForUniprot parses PDB ids', async () => {

--- a/tests/moleculeCard.test.js
+++ b/tests/moleculeCard.test.js
@@ -50,6 +50,18 @@ describe('MoleculeCard downloadSdf', () => {
     assert.strictEqual(global.document.body.children.length, 0);
     assert.strictEqual(URL.revokeObjectURL.mock.callCount(), 1);
   });
+
+  it('downloads instance SDF with proper filename', async () => {
+    mock.method(ApiService, 'getInstanceSdf', async () => 'instdata');
+    const info = { pdbId: '1ABC', authSeqId: 7, labelAsymId: 'B' };
+    await card.downloadSdf('LIG', undefined, info);
+    assert.strictEqual(ApiService.getInstanceSdf.mock.callCount(), 1);
+    assert.strictEqual(
+      createdAnchor.download,
+      '1abc_b_lig.sdf'
+    );
+    assert.strictEqual(createdAnchor.click.mock.callCount(), 1);
+  });
 });
 
 describe('MoleculeCard compare button', () => {


### PR DESCRIPTION
## Summary
- build new `getInstanceSdf` helper that supports optional component ID and filename generation
- propagate instance metadata through loader and cards for proper SDF downloads
- extend tests for instance SDF API and card download handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890aa598e78832997ef0e27b3e589e2