### PR TITLE
feat: trigger search on enter

### DIFF
--- a/src/components/ProteinBrowser.js
+++ b/src/components/ProteinBrowser.js
@@ -50,6 +50,21 @@ class ProteinBrowser {
             });
         }
 
+        if (this.searchInput) {
+            this.searchInput.addEventListener('keydown', (event) => {
+                if (event.key === 'Enter') {
+                    event.preventDefault();
+                    const queryId = this.searchInput.value.trim();
+                    if (queryId) {
+                        this.fetchProteinEntries(queryId);
+                    } else {
+                        showNotification('Please enter a Group ID or UniProt ID.', 'info');
+                    }
+                    this.searchInput.blur();
+                }
+            });
+        }
+
         if (this.hideAidsToggle) {
             this.hideAidsToggle.addEventListener('change', () => {
                 if (this.currentProteinDetails.length > 0) {

--- a/tests/proteinBrowser.test.js
+++ b/tests/proteinBrowser.test.js
@@ -45,3 +45,31 @@ describe('displayResults', () => {
     assert.ok(rowStub.innerHTML.includes('doi.org/10.1000/xyz'));
   });
 });
+
+describe('search input Enter key', () => {
+  it('triggers fetch on Enter key press', () => {
+    const searchInput = {
+      value: 'G_123',
+      addEventListener(type, handler) { this['on' + type] = handler; },
+      blur: mock.fn()
+    };
+    const searchBtn = { addEventListener: () => {} };
+    global.document = {
+      getElementById: (id) => {
+        if (id === 'protein-group-search') return searchInput;
+        if (id === 'protein-group-search-btn') return searchBtn;
+        return null;
+      }
+    };
+    const browser = new ProteinBrowser({});
+    mock.method(browser, 'fetchProteinEntries', () => {});
+    browser.init();
+    const preventDefault = mock.fn();
+    searchInput.onkeydown({ key: 'Enter', preventDefault });
+    assert.strictEqual(browser.fetchProteinEntries.mock.callCount(), 1);
+    assert.deepStrictEqual(browser.fetchProteinEntries.mock.calls[0].arguments, ['G_123']);
+    assert.strictEqual(preventDefault.mock.callCount(), 1);
+    assert.strictEqual(searchInput.blur.mock.callCount(), 1);
+    delete global.document;
+  });
+});


### PR DESCRIPTION
## Summary
- trigger protein search when pressing Enter in search input
- test search input keydown event

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c9c094d88329a0b9cfcfdbe2d1f7