### PR TITLE
feat: fetch PDB ligand instances

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@
                 <div class="instance-inputs">
                     <input type="text" id="pdb-id" placeholder="PDB ID" maxlength="4">
                     <input type="text" id="auth-seq-id" placeholder="Residue #">
-                    <input type="text" id="label-asym-id" placeholder="Chain" maxlength="2">
+                    <input type="text" id="auth-asym-id" placeholder="Chain" maxlength="2">
                 </div>
                 <p class="help-text">Optional: specify PDB ID, residue number and chain to add a bound ligand</p>
                 <p class="error-text" id="instance-error"></p>

--- a/src/components/BoundLigandTable.js
+++ b/src/components/BoundLigandTable.js
@@ -113,7 +113,7 @@ class BoundLigandTable {
             const success = this.addMolecule({
                 code: ligand.chem_comp_id,
                 pdbId,
-                labelAsymId: ligand.chain_id,
+                authAsymId: ligand.chain_id,
                 authSeqId: ligand.author_residue_number
             });
             if (success) {
@@ -150,7 +150,7 @@ class BoundLigandTable {
                 const success = this.addMolecule({
                     code: ligand.chem_comp_id,
                     pdbId,
-                    labelAsymId: ligand.chain_id,
+                    authAsymId: ligand.chain_id,
                     authSeqId: ligand.author_residue_number
                 });
                 if (success) {

--- a/src/components/ProteinBrowser.js
+++ b/src/components/ProteinBrowser.js
@@ -124,7 +124,7 @@ class ProteinBrowser {
             <div class="ligand-img-container">
                 <img src="${PD_BE_STATIC_IMAGE_BASE_URL}/${ligand.chem_comp_id}_200.svg" alt="${ligand.chem_comp_id}" title="${ligand.chem_comp_id}: ${ligand.chem_comp_name}" class="bound-ligand-img">
                 <div class="ligand-img-overlay">
-                    <button class="ligand-action-btn add-ligand" data-ccd-code="${ligand.chem_comp_id}" data-pdb-id="${pdbId}" data-label-asym-id="${ligand.chain_id}" data-auth-seq-id="${ligand.author_residue_number}">+</button>
+                    <button class="ligand-action-btn add-ligand" data-ccd-code="${ligand.chem_comp_id}" data-pdb-id="${pdbId}" data-auth-asym-id="${ligand.chain_id}" data-auth-seq-id="${ligand.author_residue_number}">+</button>
                 </div>
             </div>
         `
@@ -189,12 +189,12 @@ class ProteinBrowser {
             });
             document.querySelectorAll('.add-ligand').forEach(button => {
                 button.addEventListener('click', e => {
-                    const { ccdCode, pdbId, authSeqId, labelAsymId } = e.currentTarget.dataset;
+                    const { ccdCode, pdbId, authSeqId, authAsymId } = e.currentTarget.dataset;
                     const success = this.moleculeManager.addPdbInstance({
                         code: ccdCode,
                         pdbId,
                         authSeqId,
-                        labelAsymId
+                        authAsymId
                     });
                     if (success) {
                         showNotification(`Adding molecule ${ccdCode}...`, 'success');

--- a/src/main.js
+++ b/src/main.js
@@ -118,8 +118,8 @@ class MoleculeManager {
         return added;
     }
 
-    addPdbInstance({ code, pdbId, authSeqId, labelAsymId }) {
-        return this.addMolecule({ code, pdbId, authSeqId, labelAsymId });
+    addPdbInstance({ code, pdbId, authSeqId, authAsymId }) {
+        return this.addMolecule({ code, pdbId, authSeqId, authAsymId });
     }
 
     deleteMolecule(code) {

--- a/src/modal/AddMoleculeModal.js
+++ b/src/modal/AddMoleculeModal.js
@@ -11,7 +11,7 @@ class AddMoleculeModal {
 
         this.pdbIdInput = document.getElementById('pdb-id');
         this.authSeqIdInput = document.getElementById('auth-seq-id');
-        this.labelAsymIdInput = document.getElementById('label-asym-id');
+        this.authAsymIdInput = document.getElementById('auth-asym-id');
         this.instanceError = document.getElementById('instance-error');
 
         if (this.cancelBtn) {
@@ -35,8 +35,8 @@ class AddMoleculeModal {
         if (this.authSeqIdInput) {
             this.authSeqIdInput.addEventListener('input', () => this.handleInstanceInput());
         }
-        if (this.labelAsymIdInput) {
-            this.labelAsymIdInput.addEventListener('input', () => this.handleInstanceInput());
+        if (this.authAsymIdInput) {
+            this.authAsymIdInput.addEventListener('input', () => this.handleInstanceInput());
         }
         if (this.confirmBtn) {
             this.confirmBtn.addEventListener('click', () => this.handleSubmit());
@@ -76,8 +76,8 @@ class AddMoleculeModal {
         if (this.authSeqIdInput) {
             this.authSeqIdInput.value = '';
         }
-        if (this.labelAsymIdInput) {
-            this.labelAsymIdInput.value = '';
+        if (this.authAsymIdInput) {
+            this.authAsymIdInput.value = '';
         }
         if (this.confirmBtn) {
             this.confirmBtn.disabled = true;
@@ -106,10 +106,10 @@ class AddMoleculeModal {
         const code = this.codeInput.value.toUpperCase();
         const pdbId = this.pdbIdInput.value.trim().toUpperCase();
         const authSeqId = this.authSeqIdInput.value.trim();
-        const labelAsymId = this.labelAsymIdInput.value.trim().toUpperCase();
+        const authAsymId = this.authAsymIdInput.value.trim().toUpperCase();
 
-        if (pdbId || authSeqId || labelAsymId) {
-            if (!(pdbId && authSeqId && labelAsymId)) {
+        if (pdbId || authSeqId || authAsymId) {
+            if (!(pdbId && authSeqId && authAsymId)) {
                 if (this.instanceError) {
                     this.instanceError.textContent = 'PDB ID, residue number and chain are required.';
                 }
@@ -119,7 +119,7 @@ class AddMoleculeModal {
                 code,
                 pdbId,
                 authSeqId,
-                labelAsymId
+                authAsymId
             });
             if (success) {
                 window.showNotification(`Adding ligand ${code} from ${pdbId}...`, 'success');

--- a/src/modal/LigandDetails.js
+++ b/src/modal/LigandDetails.js
@@ -36,7 +36,7 @@ class LigandDetails {
         this.detailsType.textContent = isAminoAcid ? 'building_block' : 'reagent';
 
         const molecule = this.moleculeManager.getMolecule ? this.moleculeManager.getMolecule(ccdCode) : null;
-        const isInstance = molecule && molecule.pdbId && molecule.authSeqId && molecule.labelAsymId;
+        const isInstance = molecule && molecule.pdbId && molecule.authSeqId && molecule.authAsymId;
         if (this.detailsStructure) {
             this.detailsStructure.textContent = isInstance ? 'PDB instance' : 'Ideal CCD SDF';
         }
@@ -47,7 +47,7 @@ class LigandDetails {
         }
         if (isInstance) {
             if (this.detailsPdbId) this.detailsPdbId.textContent = molecule.pdbId.toUpperCase();
-            if (this.detailsChain) this.detailsChain.textContent = molecule.labelAsymId;
+            if (this.detailsChain) this.detailsChain.textContent = molecule.authAsymId;
             if (this.detailsResidue) this.detailsResidue.textContent = molecule.authSeqId;
         } else {
             if (this.detailsPdbId) this.detailsPdbId.textContent = '-';
@@ -96,7 +96,7 @@ class LigandDetails {
             jsonData.pdb_instance = {
                 pdb_id: molecule.pdbId,
                 auth_seq_id: molecule.authSeqId,
-                label_asym_id: molecule.labelAsymId
+                auth_asym_id: molecule.authAsymId
             };
         }
         this.detailsJSON.textContent = JSON.stringify(jsonData, null, 2);

--- a/src/utils/MoleculeLoader.js
+++ b/src/utils/MoleculeLoader.js
@@ -15,7 +15,7 @@ class MoleculeLoader {
     }
 
     async loadMolecule(input) {
-        const { code, pdbId, authSeqId, labelAsymId } =
+        const { code, pdbId, authSeqId, authAsymId } =
             typeof input === 'string' ? { code: input } : input;
         try {
             this.repository.updateMoleculeStatus(code, 'loading');
@@ -26,8 +26,8 @@ class MoleculeLoader {
                 return;
             }
             let sdfData;
-            if (pdbId && authSeqId && labelAsymId) {
-                sdfData = await ApiService.getInstanceSdf(pdbId, authSeqId, labelAsymId);
+            if (pdbId && authSeqId && authAsymId) {
+                sdfData = await ApiService.getInstanceSdf(pdbId, authSeqId, authAsymId);
             } else {
                 sdfData = await ApiService.getCcdSdf(code);
             }

--- a/src/utils/MoleculeRepository.js
+++ b/src/utils/MoleculeRepository.js
@@ -5,9 +5,9 @@ class MoleculeRepository {
 
     generateId(data) {
         if (typeof data === 'string') return data;
-        const { code, pdbId, authSeqId, labelAsymId } = data;
-        if (pdbId && authSeqId && labelAsymId) {
-            return `${pdbId}_${labelAsymId}_${authSeqId}_${code}`;
+        const { code, pdbId, authSeqId, authAsymId } = data;
+        if (pdbId && authSeqId && authAsymId) {
+            return `${pdbId}_${authAsymId}_${authSeqId}_${code}`;
         }
         return code;
     }

--- a/src/utils/apiService.js
+++ b/src/utils/apiService.js
@@ -112,12 +112,12 @@ export default class ApiService {
    *
    * @param {string} pdbId - The 4-character PDB ID
    * @param {string|number} authSeqId - Author provided residue/sequence number
-   * @param {string} labelAsymId - Chain identifier
+   * @param {string} authAsymId - Author chain identifier
    * @returns {Promise<string>} SDF file content for the ligand instance
    */
-  static getInstanceSdf(pdbId, authSeqId, labelAsymId) {
+  static getInstanceSdf(pdbId, authSeqId, authAsymId) {
     return this.fetchText(
-      `${RCSB_MODEL_BASE_URL}/${pdbId.toUpperCase()}/ligand?auth_seq_id=${authSeqId}&label_asym_id=${labelAsymId}&encoding=sdf`
+      `${RCSB_MODEL_BASE_URL}/${pdbId.toUpperCase()}/ligand?auth_asym_id=${authAsymId}&auth_seq_id=${authSeqId}&encoding=sdf`
     );
   }
   /**

--- a/tests/apiService.test.js
+++ b/tests/apiService.test.js
@@ -63,7 +63,7 @@ describe('ApiService', () => {
     const txt = await ApiService.getInstanceSdf('1abc', 7, 'B');
     assert.strictEqual(
       global.fetch.mock.calls[0].arguments[0],
-      `${RCSB_MODEL_BASE_URL}/1ABC/ligand?auth_seq_id=7&label_asym_id=B&encoding=sdf`
+      `${RCSB_MODEL_BASE_URL}/1ABC/ligand?auth_asym_id=B&auth_seq_id=7&encoding=sdf`
     );
     assert.strictEqual(txt, 'sdf');
   });

--- a/tests/moleculeLoader.test.js
+++ b/tests/moleculeLoader.test.js
@@ -40,7 +40,7 @@ describe('MoleculeLoader', () => {
 
   it('uses instance SDF when details provided', async () => {
     const repo = new MoleculeRepository([
-      { code: 'CCC', status: 'pending', pdbId: '1ABC', authSeqId: '5', labelAsymId: 'A' },
+      { code: 'CCC', status: 'pending', pdbId: '1ABC', authSeqId: '5', authAsymId: 'A' },
     ]);
     const loader = new MoleculeLoader(repo, cardUI);
     mock.method(ApiService, 'getFragmentLibraryTsv', async () => '');

--- a/tests/moleculeRepository.test.js
+++ b/tests/moleculeRepository.test.js
@@ -14,13 +14,13 @@ describe('MoleculeRepository', () => {
 
   it('stores instance metadata when provided', () => {
     const repo = new MoleculeRepository();
-    repo.addMolecule({ code: 'B', pdbId: '1ABC', authSeqId: '5', labelAsymId: 'A' });
+    repo.addMolecule({ code: 'B', pdbId: '1ABC', authSeqId: '5', authAsymId: 'A' });
     assert.deepStrictEqual(repo.getMolecule('B'), {
       code: 'B',
       status: 'pending',
       pdbId: '1ABC',
       authSeqId: '5',
-      labelAsymId: 'A',
+      authAsymId: 'A',
       id: '1ABC_A_5_B',
     });
   });
@@ -33,7 +33,7 @@ describe('MoleculeRepository', () => {
         code: 'DUP',
         pdbId: '9XYZ',
         authSeqId: '1',
-        labelAsymId: 'A',
+        authAsymId: 'A',
       })
     );
     assert.strictEqual(repo.getAllMolecules().length, 2);


### PR DESCRIPTION
## Summary
- fetch ligand instance SDFs from models API using `auth_asym_id`
- propagate `authAsymId` through loader, repository, and UI
- allow adding instances by `auth_asym_id` via modal and browser

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890d09d549c8329a37ca3f7eba4e120