### PR TITLE
feat: add hide ions toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,6 +121,11 @@
                         <label class="toggle-switch-label" for="hide-aids-toggle"></label>
                         <span>Hide Crystallization Aids</span>
                     </div>
+                    <div class="toggle-switch">
+                        <input type="checkbox" id="hide-ions-toggle" class="toggle-switch-checkbox" checked>
+                        <label class="toggle-switch-label" for="hide-ions-toggle"></label>
+                        <span>Hide Ions</span>
+                    </div>
                 </div>
                 <div id="protein-results-container">
                     <div id="protein-results-table-container" style="display: none;">

--- a/src/components/ProteinBrowser.js
+++ b/src/components/ProteinBrowser.js
@@ -4,7 +4,8 @@ import {
     RCSB_STRUCTURE_IMAGE_BASE_URL,
     RCSB_STRUCTURE_BASE_URL,
     PD_BE_ENTRY_BASE_URL,
-    CRYSTALLIZATION_AIDS
+    CRYSTALLIZATION_AIDS,
+    ION_LIGANDS
 } from '../utils/constants.js';
 
 class ProteinBrowser {
@@ -18,6 +19,7 @@ class ProteinBrowser {
         this.loadingIndicator = null;
         this.noResultsMessage = null;
         this.hideAidsToggle = null;
+        this.hideIonsToggle = null;
         this.currentProteinDetails = [];
         this.resultsCountMessage = null;
         this.loadMoreBtn = null;
@@ -36,6 +38,7 @@ class ProteinBrowser {
         this.loadingIndicator = document.getElementById('protein-loading-indicator');
         this.noResultsMessage = document.getElementById('no-protein-results-message');
         this.hideAidsToggle = document.getElementById('hide-aids-toggle');
+        this.hideIonsToggle = document.getElementById('hide-ions-toggle');
         this.resultsCountMessage = document.getElementById('protein-results-count');
         this.loadMoreBtn = document.getElementById('protein-load-more');
 
@@ -67,6 +70,14 @@ class ProteinBrowser {
 
         if (this.hideAidsToggle) {
             this.hideAidsToggle.addEventListener('change', () => {
+                if (this.currentProteinDetails.length > 0) {
+                    this.displayResults(this.currentProteinDetails);
+                }
+            });
+        }
+
+        if (this.hideIonsToggle) {
+            this.hideIonsToggle.addEventListener('change', () => {
                 if (this.currentProteinDetails.length > 0) {
                     this.displayResults(this.currentProteinDetails);
                 }
@@ -224,6 +235,7 @@ class ProteinBrowser {
         }
         if (proteinDetails && proteinDetails.length > 0) {
             const hideAids = this.hideAidsToggle && this.hideAidsToggle.checked;
+            const hideIons = this.hideIonsToggle && this.hideIonsToggle.checked;
             for (const detail of proteinDetails) {
                 const row = this.resultsBody.insertRow();
                 const pdbId = detail.rcsb_id;
@@ -245,6 +257,9 @@ class ProteinBrowser {
                 let boundLigands = await this.fetchBoundLigands(pdbId);
                 if (hideAids) {
                     boundLigands = boundLigands.filter(ligand => !CRYSTALLIZATION_AIDS.includes(ligand.chem_comp_id));
+                }
+                if (hideIons) {
+                    boundLigands = boundLigands.filter(ligand => !ION_LIGANDS.includes(ligand.chem_comp_id));
                 }
 
                 row.innerHTML = `

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -45,3 +45,4 @@ export const CRYSTALLIZATION_AIDS = [
   'ACE', 'ACT', 'BME', 'DMS', 'FMT', 'IMD', 'MES',
   'PEG', 'PGE', 'TRS'
 ];
+export const ION_LIGANDS = ['ZN', 'MG', 'CA', 'NA', 'K', 'CL'];

--- a/tests/proteinBrowser.test.js
+++ b/tests/proteinBrowser.test.js
@@ -27,6 +27,7 @@ describe('displayResults', () => {
       insertRow: () => rowStub
     };
     browser.hideAidsToggle = { checked: false };
+    browser.hideIonsToggle = { checked: false };
     browser.resultsContainer = { style: {} };
     browser.noResultsMessage = { style: {}, textContent: '' };
     mock.method(browser, 'fetchBoundLigands', async () => []);
@@ -43,6 +44,44 @@ describe('displayResults', () => {
 
     assert.ok(rowStub.innerHTML.includes('The Paper'));
     assert.ok(rowStub.innerHTML.includes('doi.org/10.1000/xyz'));
+  });
+});
+
+describe('hide ions toggle', () => {
+  it('filters ion ligands when enabled', async () => {
+    const rowStub = {
+      innerHTML: '',
+      querySelector: () => ({ addEventListener: () => {}, dataset: {} }),
+      querySelectorAll: () => []
+    };
+    const browser = new ProteinBrowser({});
+    browser.resultsBody = {
+      innerHTML: '',
+      insertRow: () => rowStub
+    };
+    browser.hideAidsToggle = { checked: false };
+    browser.hideIonsToggle = { checked: true };
+    browser.resultsContainer = { style: {} };
+    browser.noResultsMessage = { style: {}, textContent: '' };
+    mock.method(browser, 'fetchBoundLigands', async () => [
+      { chem_comp_id: 'ZN', chem_comp_name: 'Zinc' },
+      { chem_comp_id: 'ATP', chem_comp_name: 'ATP' }
+    ]);
+    browser.renderBoundLigands = mock.fn(() => '');
+
+    const details = [{
+      rcsb_id: '1ABC',
+      struct: { title: 'Structure' },
+      rcsb_entry_info: { resolution_combined: [1.5] },
+      rcsb_accession_info: { initial_release_date: '2024-01-01' },
+      rcsb_primary_citation: { title: 'Paper' }
+    }];
+
+    await browser.displayResults(details);
+    assert.deepStrictEqual(
+      browser.renderBoundLigands.mock.calls[0].arguments[0].map(l => l.chem_comp_id),
+      ['ATP']
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- add hide ions toggle alongside hide crystallization aids
- filter bound ligands matching common ion codes when enabled
- test ion filtering behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890d23573f483298bc2d24e1927a36c