### PR TITLE
Add global molecule viewer and view actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -385,7 +385,7 @@
                             <th>Residue No.</th>
                             <th>Entity ID</th>
                             <th>Name</th>
-                            <th>Add</th>
+                            <th>Actions</th>
                         </tr>
                     </thead>
                     <tbody id="bound-ligands-tbody">
@@ -419,7 +419,7 @@
                 <span class="close" id="close-quick-view-modal">&times;</span>
             </div>
             <div class="modal-body" style="padding: 10px;">
-                <div id="quick-view-viewer" style="width: 100%; height: 300px; position: relative;">
+                <div id="quick-view-viewer" class="viewer-container" style="width: 100%; height: 300px; position: relative;">
                     <p>Loading...</p>
                 </div>
             </div>

--- a/src/components/BoundLigandTable.js
+++ b/src/components/BoundLigandTable.js
@@ -104,7 +104,10 @@ class BoundLigandTable {
         nameCell.textContent = ligand.chem_comp_name;
         nameCell.title = ligand.chem_comp_name;
 
-        const addCell = document.createElement('td');
+        const actionsCell = document.createElement('td');
+        actionsCell.style.display = 'flex';
+        actionsCell.style.gap = '4px';
+        actionsCell.style.justifyContent = 'center';
         const addButton = document.createElement('button');
         addButton.className = 'add-ligand-btn';
         addButton.innerHTML = '&#43;';
@@ -122,7 +125,26 @@ class BoundLigandTable {
                 showNotification(`Molecule ${ligand.chem_comp_id} already exists`, 'info');
             }
         });
-        addCell.appendChild(addButton);
+        actionsCell.appendChild(addButton);
+
+        const viewButton = document.createElement('button');
+        viewButton.className = 'view-ligand-btn';
+        viewButton.innerHTML = '👁';
+        viewButton.title = `View ${ligand.chem_comp_id}`;
+        viewButton.addEventListener('click', async () => {
+            try {
+                const sdf = await ApiService.getCcdSdf(ligand.chem_comp_id);
+                if (window.viewer) {
+                    window.viewer.addMolecule({ code: ligand.chem_comp_id, sdf });
+                    window.moleculeManager?.repository.addViewerMolecule({ code: ligand.chem_comp_id, sdf });
+                    showNotification(`Sent ${ligand.chem_comp_id} to viewer`, 'success');
+                }
+            } catch (e) {
+                console.error('Error fetching SDF for viewer:', e);
+                showNotification(`Failed to load ${ligand.chem_comp_id}`, 'error');
+            }
+        });
+        actionsCell.appendChild(viewButton);
 
         row.appendChild(imageCell);
         row.appendChild(codeCell);
@@ -130,7 +152,7 @@ class BoundLigandTable {
         row.appendChild(residueCell);
         row.appendChild(entityCell);
         row.appendChild(nameCell);
-        row.appendChild(addCell);
+        row.appendChild(actionsCell);
 
         return row;
     }

--- a/src/components/MoleculeCard.js
+++ b/src/components/MoleculeCard.js
@@ -52,6 +52,8 @@ class MoleculeCard {
         });
         card.appendChild(compareBtn);
 
+
+
         const codeLabel = document.createElement('div');
         codeLabel.className = 'molecule-code';
         codeLabel.textContent = ccdCode;
@@ -127,6 +129,22 @@ class MoleculeCard {
             if (this.onCompare) this.onCompare(ccdCode);
         });
         card.appendChild(compareBtn);
+
+        const viewBtn = document.createElement('div');
+        viewBtn.className = 'view-btn';
+        viewBtn.textContent = '\ud83d\udc41';
+        viewBtn.title = `View ${ccdCode}`;
+        viewBtn.addEventListener('click', e => {
+            e.stopPropagation();
+            if (window.viewer) {
+                window.viewer.addMolecule({ code: ccdCode, sdf: data });
+                window.moleculeManager?.repository.addViewerMolecule({ code: ccdCode, sdf: data });
+                if (typeof showNotification === 'function') {
+                    showNotification(`Sent ${ccdCode} to viewer`, 'success');
+                }
+            }
+        });
+        card.appendChild(viewBtn);
 
         const title = document.createElement('h3');
         title.textContent = ccdCode;

--- a/src/components/Viewer.js
+++ b/src/components/Viewer.js
@@ -1,0 +1,73 @@
+class Viewer {
+    constructor(containerId = 'quick-view-viewer') {
+        this.containerId = containerId;
+        this.container = null;
+        this.viewer = null;
+        this.models = new Map();
+    }
+
+    init(initial = []) {
+        this.container = document.getElementById(this.containerId);
+        if (!this.container) {
+            console.warn(`Viewer container #${this.containerId} not found`);
+            return this;
+        }
+        this.container.innerHTML = '';
+        try {
+            const bgColor = document.body?.classList?.contains('dark-mode') ? '#e0e0e0' : 'white';
+            this.viewer = $3Dmol.createViewer(this.container, { backgroundColor: bgColor });
+            this.viewer.render();
+        } catch (e) {
+            console.error('Error initializing viewer:', e);
+        }
+        if (Array.isArray(initial) && initial.length > 0) {
+            this.restore(initial);
+        }
+        return this;
+    }
+
+    addMolecule({ code, sdf }) {
+        if (!this.viewer || !sdf || !code) return;
+        if (this.models.has(code)) return;
+        try {
+            const model = this.viewer.addModel(sdf, 'sdf');
+            this.viewer.setStyle({ model }, { stick: {} });
+            this.viewer.setStyle({ model, elem: 'H' }, {});
+            this.viewer.zoomTo();
+            this.viewer.render();
+            this.models.set(code, { model, sdf });
+        } catch (e) {
+            console.error(`Error adding molecule ${code} to viewer:`, e);
+        }
+    }
+
+    removeMolecule(code) {
+        if (!this.viewer || !this.models.has(code)) return;
+        try {
+            const { model } = this.models.get(code);
+            this.viewer.removeModel(model);
+            this.models.delete(code);
+            this.viewer.render();
+        } catch (e) {
+            console.error(`Error removing molecule ${code} from viewer:`, e);
+        }
+    }
+
+    clear() {
+        if (this.viewer) {
+            this.viewer.removeAllModels();
+            this.viewer.render();
+        }
+        this.models.clear();
+    }
+
+    restore(molecules = []) {
+        molecules.forEach(m => this.addMolecule(m));
+    }
+
+    getState() {
+        return Array.from(this.models.entries()).map(([code, { sdf }]) => ({ code, sdf }));
+    }
+}
+
+export default Viewer;

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ import PdbDetailsModal from './modal/PdbDetailsModal.js';
 import AddMoleculeModal from './modal/AddMoleculeModal.js';
 import ProteinBrowser from './components/ProteinBrowser.js';
 import ComparisonModal from './modal/ComparisonModal.js';
+import Viewer from './components/Viewer.js';
 
 class MoleculeManager {
     constructor() {
@@ -132,6 +133,10 @@ class MoleculeManager {
         if (this.repository.removeMolecule(code)) {
             const card = this.grid.querySelector(`[data-molecule-code="${code}"]`);
             if (card) card.remove();
+            this.repository.removeViewerMolecule(code);
+            if (window.viewer) {
+                window.viewer.removeMolecule(code);
+            }
             return true;
         }
         return false;
@@ -139,8 +144,12 @@ class MoleculeManager {
 
     deleteAllMolecules() {
         this.repository.clearAll();
+        this.repository.clearViewerState();
         if (this.cardUI) {
             this.cardUI.clearAll();
+        }
+        if (window.viewer) {
+            window.viewer.clear();
         }
         showNotification('All molecules deleted successfully!', 'info');
     }
@@ -215,6 +224,9 @@ class MoleculeManager {
 }
 
 const moleculeManager = new MoleculeManager().init();
+const viewer = new Viewer().init(
+    moleculeManager.repository.getViewerMolecules()
+);
 moleculeManager.loadAllMolecules();
 
 const rdkitPromise =
@@ -326,6 +338,7 @@ function showNotification(message, type = 'info') {
 window.moleculeManager = moleculeManager;
 window.fragmentLibrary = fragmentLibrary;
 window.proteinBrowser = proteinBrowser;
+window.viewer = viewer;
 window.showNotification = showNotification;
 
 function toggleDarkMode() {

--- a/src/utils/MoleculeRepository.js
+++ b/src/utils/MoleculeRepository.js
@@ -1,6 +1,7 @@
 class MoleculeRepository {
     constructor(initial = []) {
         this.molecules = initial.map(m => ({ ...m, id: this.generateId(m) }));
+        this.viewerMolecules = [];
     }
 
     generateId(data) {
@@ -61,6 +62,24 @@ class MoleculeRepository {
 
     clearAll() {
         this.molecules = [];
+    }
+
+    addViewerMolecule(mol) {
+        if (!mol || !mol.code || !mol.sdf) return;
+        if (this.viewerMolecules.find(m => m.code === mol.code)) return;
+        this.viewerMolecules.push({ code: mol.code, sdf: mol.sdf });
+    }
+
+    removeViewerMolecule(code) {
+        this.viewerMolecules = this.viewerMolecules.filter(m => m.code !== code);
+    }
+
+    getViewerMolecules() {
+        return [...this.viewerMolecules];
+    }
+
+    clearViewerState() {
+        this.viewerMolecules = [];
     }
 
     removeHydrogensFromSdf(sdf) {

--- a/style.css
+++ b/style.css
@@ -1307,6 +1307,45 @@ main {
     pointer-events: none;
 }
 
+.view-btn {
+    position: absolute;
+    top: 8px;
+    right: 104px;
+    cursor: pointer;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.3s ease;
+    user-select: none;
+    z-index: 10;
+    opacity: 0.5;
+    background-color: transparent;
+    color: #757575;
+}
+
+.view-btn:hover {
+    opacity: 1;
+    background-color: #fff3e0;
+    color: #ef6c00;
+    transform: scale(1.1);
+}
+
+.view-btn:active {
+    transform: scale(0.9);
+    background-color: #ffe0b2;
+}
+
+.molecule-card:hover .view-btn {
+    opacity: 0.7;
+}
+
+.view-btn svg {
+    pointer-events: none;
+}
+
 .molecule-card.dragging {
     opacity: 0.5;
     transform: rotate(5deg);
@@ -1520,6 +1559,26 @@ main {
 
 .add-ligand-btn:hover {
     background-color: #5838b4;
+}
+
+.view-ligand-btn {
+    background-color: #009688;
+    color: white;
+    border: none;
+    border-radius: 50%;
+    width: 28px;
+    height: 28px;
+    font-size: 16px;
+    line-height: 28px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.view-ligand-btn:hover {
+    background-color: #00796b;
 }
 
 /* Disclaimer Modal Styles */


### PR DESCRIPTION
## Summary
- integrate a reusable Viewer and instantiate it alongside the MoleculeManager
- allow molecules and bound ligands to be sent to the Viewer and track viewer state in the repository
- remove viewer models when molecules are deleted and clear viewer on mass deletions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890dd6dd5e883298b4a85b5dbfeb6d2