### PR TITLE
Add viewer row controls with hide and remove actions

### DIFF
--- a/src/Viewer.js
+++ b/src/Viewer.js
@@ -1,0 +1,83 @@
+class Viewer {
+  constructor(viewer, listEl) {
+    this.viewer = viewer;
+    this.listEl = listEl;
+    this.entries = [];
+  }
+
+  addModel(model, label = '') {
+    const row = document.createElement('div');
+    row.className = 'viewer-row';
+
+    const nameSpan = document.createElement('span');
+    nameSpan.textContent = label;
+    row.appendChild(nameSpan);
+
+    const toggleBtn = document.createElement('button');
+    toggleBtn.className = 'visibility-toggle';
+    toggleBtn.textContent = '👁';
+    row.appendChild(toggleBtn);
+
+    const removeBtn = document.createElement('button');
+    removeBtn.className = 'remove-model';
+    removeBtn.textContent = '✖';
+    row.appendChild(removeBtn);
+
+    if (this.listEl && typeof this.listEl.appendChild === 'function') {
+      this.listEl.appendChild(row);
+    }
+
+    const entry = { model, row, visible: true, style: { stick: {} } };
+    this.entries.push(entry);
+
+    toggleBtn.addEventListener('click', () => {
+      entry.visible = !entry.visible;
+      if (entry.visible) {
+        model.setStyle({}, entry.style);
+        row.classList.remove('model-hidden');
+        if (!row.style) row.style = {};
+        row.style.opacity = '1';
+        row.style.textDecoration = '';
+      } else {
+        model.setStyle({}, {});
+        row.classList.add('model-hidden');
+        if (!row.style) row.style = {};
+        row.style.opacity = '0.5';
+        row.style.textDecoration = 'line-through';
+      }
+      if (this.viewer && typeof this.viewer.render === 'function') {
+        this.viewer.render();
+      }
+    });
+
+    removeBtn.addEventListener('click', () => {
+      if (this.viewer && typeof this.viewer.removeModel === 'function') {
+        this.viewer.removeModel(model);
+      }
+      const idx = this.entries.findIndex(e => e.model === model);
+      if (idx !== -1) {
+        this.entries.splice(idx, 1);
+      }
+      if (this.listEl) {
+        if (typeof row.remove === 'function') {
+          row.remove();
+        } else if (Array.isArray(this.listEl.children)) {
+          const i = this.listEl.children.indexOf(row);
+          if (i > -1) {
+            this.listEl.children.splice(i, 1);
+          }
+        }
+      }
+      if (this.viewer && typeof this.viewer.zoomTo === 'function') {
+        this.viewer.zoomTo();
+      }
+      if (this.viewer && typeof this.viewer.render === 'function') {
+        this.viewer.render();
+      }
+    });
+
+    return row;
+  }
+}
+
+export default Viewer;

--- a/tests/viewer.test.js
+++ b/tests/viewer.test.js
@@ -1,0 +1,55 @@
+import { describe, it, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import Viewer from '../src/Viewer.js';
+
+describe('Viewer row controls', () => {
+  let container, viewerObj, model, viewer, row, toggleBtn, removeBtn;
+
+  const makeEl = () => ({
+    children: [],
+    className: '',
+    classList: {
+      classes: new Set(),
+      add(...cls) { cls.forEach(c => this.classes.add(c)); },
+      remove(...cls) { cls.forEach(c => this.classes.delete(c)); },
+      contains(c) { return this.classes.has(c); }
+    },
+    style: {},
+    appendChild(child) { this.children.push(child); return child; },
+    removeChild(child) { const i = this.children.indexOf(child); if (i > -1) this.children.splice(i,1); },
+    addEventListener(type, handler) { this['on'+type] = handler; },
+    dispatchEvent(evt) { const h = this['on'+evt.type]; if (h) h(evt); },
+    textContent: ''
+  });
+
+  beforeEach(() => {
+    container = makeEl();
+    global.document = { createElement: makeEl };
+    viewerObj = { removeModel: mock.fn(), zoomTo: mock.fn(), render: mock.fn() };
+    model = { setStyle: mock.fn() };
+    viewer = new Viewer(viewerObj, container);
+    viewer.addModel(model, 'm1');
+    row = container.children[0];
+    toggleBtn = row.children[1];
+    removeBtn = row.children[2];
+  });
+
+  it('toggles visibility and updates styling', () => {
+    toggleBtn.dispatchEvent({ type: 'click' });
+    assert.deepStrictEqual(model.setStyle.mock.calls[0].arguments, [{}, {}]);
+    assert.ok(row.classList.contains('model-hidden'));
+    toggleBtn.dispatchEvent({ type: 'click' });
+    assert.deepStrictEqual(model.setStyle.mock.calls[1].arguments, [{}, { stick: {} }]);
+    assert.ok(!row.classList.contains('model-hidden'));
+    assert.strictEqual(viewerObj.render.mock.callCount(), 2);
+  });
+
+  it('removes model and row then rezooms', () => {
+    removeBtn.dispatchEvent({ type: 'click' });
+    assert.strictEqual(viewerObj.removeModel.mock.callCount(), 1);
+    assert.strictEqual(viewerObj.removeModel.mock.calls[0].arguments[0], model);
+    assert.strictEqual(container.children.length, 0);
+    assert.strictEqual(viewerObj.zoomTo.mock.callCount(), 1);
+    assert.strictEqual(viewerObj.render.mock.callCount(), 1);
+  });
+});


### PR DESCRIPTION
## Summary
- implement a simple `Viewer` helper that renders model rows with visibility toggle and remove icon
- dim and strike rows when hidden, remove rows and re-zoom viewer when models are deleted
- add tests covering row visibility toggling and model removal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890dd8136f883298a13becbed2fdcd2