### PR TITLE
refactor: remove window globals

### DIFF
--- a/src/components/BoundLigandTable.js
+++ b/src/components/BoundLigandTable.js
@@ -2,10 +2,11 @@ import ApiService from '../utils/apiService.js';
 import { EXCLUDED_LIGANDS, ADD_LIGAND_DELAY_MS } from '../utils/constants.js';
 
 class BoundLigandTable {
-    constructor(addMolecule, showMoleculeDetails, ligandModal) {
+    constructor(addMolecule, showMoleculeDetails, ligandModal, notify = () => {}) {
         this.addMolecule = addMolecule;
         this.showMoleculeDetails = showMoleculeDetails;
         this.ligandModal = ligandModal;
+        this.showNotification = notify;
     }
 
     populateBoundLigands(pdbId) {
@@ -58,8 +59,8 @@ class BoundLigandTable {
                 const msg = error.status && error.url
                     ? `Failed to load bound ligands (status ${error.status}) from ${error.url}`
                     : 'Failed to load bound ligand data.';
-                if (typeof showNotification === 'function') {
-                    showNotification(msg, 'error');
+                if (this.showNotification) {
+                    this.showNotification(msg, 'error');
                 }
             });
     }
@@ -117,9 +118,9 @@ class BoundLigandTable {
                 authSeqId: ligand.author_residue_number
             });
             if (success) {
-                showNotification(`Adding molecule ${ligand.chem_comp_id}...`, 'success');
+                this.showNotification(`Adding molecule ${ligand.chem_comp_id}...`, 'success');
             } else {
-                showNotification(`Molecule ${ligand.chem_comp_id} already exists`, 'info');
+                this.showNotification(`Molecule ${ligand.chem_comp_id} already exists`, 'info');
             }
         });
         addCell.appendChild(addButton);
@@ -137,7 +138,7 @@ class BoundLigandTable {
 
     addAllLigands(ligandList, type, pdbId) {
         if (!ligandList || ligandList.length === 0) {
-            showNotification(`No ${type} ligands to add`, 'info');
+            this.showNotification(`No ${type} ligands to add`, 'info');
             return;
         }
         const addAllBtn = document.getElementById(`add-all-${type}-btn`);
@@ -167,7 +168,7 @@ class BoundLigandTable {
                     } else {
                         message = `All ${skippedCount} molecules already existed`;
                     }
-                    showNotification(message, addedCount > 0 ? 'success' : 'info');
+                    this.showNotification(message, addedCount > 0 ? 'success' : 'info');
                     addAllBtn.disabled = false;
                     addAllBtn.textContent = `Add All (${ligandList.length})`;
                 }

--- a/src/components/FragmentLibrary.js
+++ b/src/components/FragmentLibrary.js
@@ -2,8 +2,7 @@ import ApiService from '../utils/apiService.js';
 
 class FragmentLibrary {
     constructor(moleculeManager, {
-        notify = (typeof window !== 'undefined' && window.showNotification)
-            || (typeof showNotification === 'function' ? showNotification : () => {}),
+        notify = () => {},
         rdkit = Promise.resolve(null)
     } = {}) {
         this.moleculeManager = moleculeManager;

--- a/src/components/ProteinBrowser.js
+++ b/src/components/ProteinBrowser.js
@@ -8,8 +8,9 @@ import {
 } from '../utils/constants.js';
 
 class ProteinBrowser {
-    constructor(moleculeManager) {
+    constructor(moleculeManager, notify = () => {}) {
         this.moleculeManager = moleculeManager;
+        this.showNotification = notify;
         this.searchBtn = null;
         this.searchInput = null;
         this.suggestedDropdown = null;
@@ -45,7 +46,7 @@ class ProteinBrowser {
                 if (queryId) {
                     this.fetchProteinEntries(queryId);
                 } else {
-                    showNotification('Please enter a Group ID or UniProt ID.', 'info');
+                    this.showNotification('Please enter a Group ID or UniProt ID.', 'info');
                 }
             });
         }
@@ -58,7 +59,7 @@ class ProteinBrowser {
                     if (queryId) {
                         this.fetchProteinEntries(queryId);
                     } else {
-                        showNotification('Please enter a Group ID or UniProt ID.', 'info');
+                        this.showNotification('Please enter a Group ID or UniProt ID.', 'info');
                     }
                     this.searchInput.blur();
                 }
@@ -129,9 +130,7 @@ class ProteinBrowser {
             const msg = error.status && error.url
                 ? `Failed to fetch protein data (status ${error.status}) from ${error.url}`
                 : 'Failed to fetch protein data.';
-            if (typeof showNotification === 'function') {
-                showNotification(msg, 'error');
-            }
+            this.showNotification(msg, 'error');
         } finally {
             this.loadingIndicator.style.display = 'none';
         }
@@ -160,9 +159,7 @@ class ProteinBrowser {
             this.updateResultsInfo();
         } catch (error) {
             console.error('Error loading more results:', error);
-            if (typeof showNotification === 'function') {
-                showNotification('Failed to load more protein entries.', 'error');
-            }
+            this.showNotification('Failed to load more protein entries.', 'error');
         } finally {
             this.loadingIndicator.style.display = 'none';
         }
@@ -287,9 +284,9 @@ class ProteinBrowser {
                             labelAsymId
                         });
                         if (success) {
-                            showNotification(`Adding molecule ${ccdCode}...`, 'success');
+                            this.showNotification(`Adding molecule ${ccdCode}...`, 'success');
                         } else {
-                            showNotification(`Molecule ${ccdCode} already exists`, 'info');
+                            this.showNotification(`Molecule ${ccdCode} already exists`, 'info');
                         }
                     });
                 });

--- a/src/main.js
+++ b/src/main.js
@@ -39,14 +39,15 @@ class MoleculeManager {
         });
 
         this.loader = new MoleculeLoader(this.repository, this.cardUI);
-        this.ligandModal = new LigandModal(this);
+        this.ligandModal = new LigandModal(this, showNotification);
         this.boundLigandTable = new BoundLigandTable(
             molecule => this.addMolecule(molecule),
             code => this.showMoleculeDetails(code),
-            this.ligandModal
+            this.ligandModal,
+            showNotification
         );
-        this.pdbDetailsModal = new PdbDetailsModal(this.boundLigandTable);
-        this.addModal = new AddMoleculeModal(this);
+        this.pdbDetailsModal = new PdbDetailsModal(this.boundLigandTable, showNotification);
+        this.addModal = new AddMoleculeModal(this, showNotification);
         this.comparisonModal = new ComparisonModal();
 
         document.getElementById('add-molecule-btn').addEventListener('click', () => {
@@ -281,7 +282,7 @@ if (confirmAddFragmentBtn) {
     });
 }
 
-const proteinBrowser = new ProteinBrowser(moleculeManager).init();
+const proteinBrowser = new ProteinBrowser(moleculeManager, showNotification).init();
 
 function showNotification(message, type = 'info') {
     const notification = document.createElement('div');
@@ -323,10 +324,6 @@ function showNotification(message, type = 'info') {
     }, 3000);
 }
 
-window.moleculeManager = moleculeManager;
-window.fragmentLibrary = fragmentLibrary;
-window.proteinBrowser = proteinBrowser;
-window.showNotification = showNotification;
 
 function toggleDarkMode() {
     document.body.classList.toggle('dark-mode');

--- a/src/modal/AddMoleculeModal.js
+++ b/src/modal/AddMoleculeModal.js
@@ -3,8 +3,9 @@ export const luckyDepCodes = [
 ];
 
 class AddMoleculeModal {
-    constructor(moleculeManager) {
+    constructor(moleculeManager, notify = () => {}) {
         this.moleculeManager = moleculeManager;
+        this.showNotification = notify;
         this.modal = document.getElementById('add-molecule-modal');
         this.codeInput = document.getElementById('molecule-code');
         this.errorText = document.getElementById('ccd-error');
@@ -123,9 +124,9 @@ class AddMoleculeModal {
 
         const success = this.moleculeManager.addMolecule(code);
         if (success) {
-            window.showNotification(`Adding molecule ${code}...`, 'success');
+            this.showNotification(`Adding molecule ${code}...`, 'success');
         } else {
-            window.showNotification(`Molecule ${code} already exists`, 'info');
+            this.showNotification(`Molecule ${code} already exists`, 'info');
         }
         this.close();
     }
@@ -150,16 +151,16 @@ class AddMoleculeModal {
                 labelAsymId
             });
             if (success) {
-                window.showNotification(`Adding ligand ${code} from ${pdbId}...`, 'success');
+                this.showNotification(`Adding ligand ${code} from ${pdbId}...`, 'success');
             } else {
-                window.showNotification(`Ligand ${code} instance already exists`, 'info');
+                this.showNotification(`Ligand ${code} instance already exists`, 'info');
             }
         } else {
             const success = this.moleculeManager.addMolecule(code);
             if (success) {
-                window.showNotification(`Adding molecule ${code}...`, 'success');
+                this.showNotification(`Adding molecule ${code}...`, 'success');
             } else {
-                window.showNotification(`Molecule ${code} already exists`, 'info');
+                this.showNotification(`Molecule ${code} already exists`, 'info');
             }
         }
         this.close();

--- a/src/modal/LigandModal.js
+++ b/src/modal/LigandModal.js
@@ -5,9 +5,9 @@ import PropertyCalculator from '../utils/propertyCalculator.js';
 import ApiService from '../utils/apiService.js';
 
 class LigandModal {
-    constructor(moleculeManager) {
+    constructor(moleculeManager, notify = () => {}) {
         this.details = new LigandDetails(moleculeManager);
-        this.similarLigandTable = new SimilarLigandTable(moleculeManager);
+        this.similarLigandTable = new SimilarLigandTable(moleculeManager, notify);
         this.pdbEntryList = new PdbEntryList(moleculeManager);
         this.propertiesContainer = document.getElementById('ligand-properties');
     }

--- a/src/modal/PdbDetailsModal.js
+++ b/src/modal/PdbDetailsModal.js
@@ -2,8 +2,9 @@ import ApiService from '../utils/apiService.js';
 import { RCSB_STRUCTURE_BASE_URL, PD_BE_ENTRY_BASE_URL } from '../utils/constants.js';
 
 class PdbDetailsModal {
-    constructor(boundLigandTable) {
+    constructor(boundLigandTable, notify = () => {}) {
         this.boundLigandTable = boundLigandTable;
+        this.showNotification = notify;
         this.modal = document.getElementById('pdb-details-modal');
         const closeBtn = document.getElementById('close-pdb-details-modal');
         if (closeBtn) {
@@ -89,8 +90,8 @@ class PdbDetailsModal {
             const msg = error.status && error.url
                 ? `Failed to load PDB details (status ${error.status}) from ${error.url}`
                 : 'Failed to load PDB entry details.';
-            if (typeof showNotification === 'function') {
-                showNotification(msg, 'error');
+            if (this.showNotification) {
+                this.showNotification(msg, 'error');
             }
         }
     }

--- a/src/modal/SimilarLigandTable.js
+++ b/src/modal/SimilarLigandTable.js
@@ -2,9 +2,10 @@ import ApiService from '../utils/apiService.js';
 import { PD_BE_STATIC_IMAGE_BASE_URL } from '../utils/constants.js';
 
 class SimilarLigandTable {
-    constructor(moleculeManager) {
+    constructor(moleculeManager, notify = () => {}) {
         this.moleculeManager = moleculeManager;
         this.currentSimilarLigands = [];
+        this.showNotification = notify;
     }
 
     async load(ccdCode) {
@@ -64,7 +65,7 @@ class SimilarLigandTable {
 
     addAllSimilarLigands() {
         if (!this.currentSimilarLigands || this.currentSimilarLigands.length === 0) {
-            showNotification('No similar ligands to add', 'info');
+            this.showNotification('No similar ligands to add', 'info');
             return;
         }
 
@@ -94,7 +95,7 @@ class SimilarLigandTable {
                         message = `All ${skippedCount} molecules already existed`;
                     }
 
-                    showNotification(message, addedCount > 0 ? 'success' : 'info');
+                    this.showNotification(message, addedCount > 0 ? 'success' : 'info');
                     addAllBtn.disabled = false;
                     addAllBtn.textContent = `Add All (${this.currentSimilarLigands.length})`;
                 }
@@ -165,9 +166,9 @@ class SimilarLigandTable {
         addButton.addEventListener('click', () => {
             const success = this.moleculeManager.addMolecule(ligand.chem_comp_id);
             if (success) {
-                showNotification(`Adding molecule ${ligand.chem_comp_id}...`, 'success');
+                this.showNotification(`Adding molecule ${ligand.chem_comp_id}...`, 'success');
             } else {
-                showNotification(`Molecule ${ligand.chem_comp_id} already exists`, 'info');
+                this.showNotification(`Molecule ${ligand.chem_comp_id} already exists`, 'info');
             }
         });
         addCell.appendChild(addButton);

--- a/tests/addMoleculeModal.test.js
+++ b/tests/addMoleculeModal.test.js
@@ -6,6 +6,7 @@ import AddMoleculeModal, { luckyDepCodes } from '../src/modal/AddMoleculeModal.j
 let dom;
 let manager;
 let luckyBtn;
+let showNotification;
 
 const setupDom = () => {
   dom = new JSDOM();
@@ -20,8 +21,7 @@ const setupDom = () => {
   dom.window.addEventListener = () => {};
   global.window = dom.window;
   global.document = document;
-  global.showNotification = mock.fn();
-  dom.window.showNotification = global.showNotification;
+  showNotification = mock.fn();
 
   const modal = document.createElement('div');
   const codeInput = document.createElement('input');
@@ -59,11 +59,12 @@ describe('AddMoleculeModal lucky button', () => {
 
   afterEach(() => {
     mock.restoreAll();
-    delete global.showNotification;
+    delete global.window;
+    delete global.document;
   });
 
   it('adds random molecule from luckyDepCodes', () => {
-    const modal = new AddMoleculeModal(manager);
+    const modal = new AddMoleculeModal(manager, showNotification);
 
     modal.handleLucky();
 

--- a/tests/boundLigandTable.test.js
+++ b/tests/boundLigandTable.test.js
@@ -7,6 +7,7 @@ import ApiService from '../src/utils/apiService.js';
 let dom;
 let table;
 let addMoleculeStub;
+let showNotification;
 
 const setupDom = () => {
   dom = new JSDOM();
@@ -24,7 +25,7 @@ const setupDom = () => {
   };
   global.window = dom.window;
   global.document = document;
-  global.showNotification = mock.fn();
+  showNotification = mock.fn();
 
   const section = document.createElement('div');
   const tableEl = document.createElement('table');
@@ -41,12 +42,13 @@ const setupDom = () => {
 beforeEach(() => {
   setupDom();
   addMoleculeStub = mock.fn(() => true);
-  table = new BoundLigandTable(addMoleculeStub, () => {}, null);
+  table = new BoundLigandTable(addMoleculeStub, () => {}, null, showNotification);
 });
 
 afterEach(() => {
   mock.restoreAll();
-  delete global.showNotification;
+  delete global.window;
+  delete global.document;
 });
 
 describe('populateBoundLigands', () => {

--- a/tests/ligandModal.test.js
+++ b/tests/ligandModal.test.js
@@ -24,7 +24,7 @@ describe('LigandModal orchestrator', () => {
     mock.method(PropertyCalculator, 'getProperties', async () => null);
     mock.method(ApiService, 'getPubChemMetadata', async () => null);
 
-    const lm = new LigandModal({});
+    const lm = new LigandModal({}, () => {});
     lm.show('ATP', 'sdf');
     lm.load2DStructure('ATP', 'container');
 
@@ -60,7 +60,7 @@ describe('LigandModal properties panel', () => {
     mock.method(PropertyCalculator, 'getProperties', async () => ({ molecularWeight: 55, formula: 'C2H6O', atomCount: 9, heavyAtomCount: 3, aromaticBondCount: 1 }));
     mock.method(ApiService, 'getPubChemMetadata', async () => ({ properties: null, synonyms: [], link: null }));
 
-    const lm = new LigandModal({});
+    const lm = new LigandModal({}, () => {});
     lm.show('ETH', 'sdf');
     await new Promise(setImmediate);
     assert.ok(propsEl.innerHTML.includes('55'));
@@ -88,7 +88,7 @@ describe('LigandModal properties panel', () => {
     mock.method(PropertyCalculator, 'getProperties', async () => { throw new Error('fail'); });
     mock.method(ApiService, 'getPubChemMetadata', async () => { throw new Error('fail'); });
 
-    const lm = new LigandModal({});
+    const lm = new LigandModal({}, () => {});
     lm.show('BAD', 'sdf');
     await new Promise(setImmediate);
     assert.strictEqual(propsEl.textContent, 'Properties unavailable');
@@ -120,7 +120,7 @@ describe('LigandModal metadata retrieval', () => {
       link: 'https://pubchem.ncbi.nlm.nih.gov/compound/123'
     }));
 
-    const lm = new LigandModal({});
+    const lm = new LigandModal({}, () => {});
     lm.show('WAT', 'sdf');
     await new Promise(setImmediate);
     assert.ok(propsEl.innerHTML.includes('Foo'));


### PR DESCRIPTION
## Summary
- stop exporting app objects on `window` and pass `showNotification` into components
- inject notification handlers into ligand, fragment and protein utilities
- update tests to pass mock notification callbacks

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890cec372c48329843f26aed325dd2a