### PR TITLE
Handle long author lists in protein modal

### DIFF
--- a/src/modal/PdbDetailsModal.js
+++ b/src/modal/PdbDetailsModal.js
@@ -103,7 +103,16 @@ class PdbDetailsModal {
 
     createPDBDetailsHTML(data) {
         const title = data.struct?.title || 'Not available';
-        const authors = data.citation?.[0]?.rcsb_authors?.join(', ') || 'Not available';
+        const authorList = data.citation?.[0]?.rcsb_authors || [];
+        let fullAuthors = 'Not available';
+        let displayAuthors = 'Not available';
+        if (authorList.length > 0) {
+            fullAuthors = authorList.join(', ');
+            displayAuthors = fullAuthors;
+            if (authorList.length > 4) {
+                displayAuthors = `${authorList.slice(0, 2).join(', ')}, ..., ${authorList.slice(-2).join(', ')}`;
+            }
+        }
         const releaseDate = data.rcsb_accession_info?.initial_release_date ? new Date(data.rcsb_accession_info.initial_release_date).toLocaleDateString() : 'Not available';
         const resolution = data.rcsb_entry_info?.resolution_combined?.[0]?.toFixed(2) ? `${data.rcsb_entry_info.resolution_combined[0].toFixed(2)} Å` : 'N/A';
         const method = data.exptl?.[0]?.method || 'N/A';
@@ -143,7 +152,7 @@ class PdbDetailsModal {
                     </div>
                     <div class="pdb-info-item" style="grid-column: 1 / -1;">
                         <div class="pdb-info-label">Authors</div>
-                        <div class="pdb-info-value">${authors}</div>
+                        <div class="pdb-info-value authors-list" title="${fullAuthors}">${displayAuthors}</div>
                     </div>
                 </div>
                 <div class="pdb-external-links">

--- a/src/modal/PdbDetailsModal.js
+++ b/src/modal/PdbDetailsModal.js
@@ -109,8 +109,8 @@ class PdbDetailsModal {
         if (authorList.length > 0) {
             fullAuthors = authorList.join(', ');
             displayAuthors = fullAuthors;
-            if (authorList.length > 6) {
-                displayAuthors = `${authorList.slice(0, 3).join(', ')}, ..., ${authorList.slice(-3).join(', ')}`;
+            if (authorList.length > 4) {
+                displayAuthors = `${authorList.slice(0, 2).join(', ')}, ..., ${authorList.slice(-2).join(', ')}`;
             }
         }
         const releaseDate = data.rcsb_accession_info?.initial_release_date ? new Date(data.rcsb_accession_info.initial_release_date).toLocaleDateString() : 'Not available';
@@ -152,7 +152,10 @@ class PdbDetailsModal {
                     </div>
                     <div class="pdb-info-item" style="grid-column: 1 / -1;">
                         <div class="pdb-info-label">Authors</div>
-                        <div class="pdb-info-value authors-list" title="${fullAuthors}">${displayAuthors}</div>
+                        <div class="pdb-info-value authors-list">
+                            <span class="authors-display">${displayAuthors}</span>
+                            <div class="authors-tooltip">${fullAuthors}</div>
+                        </div>
                     </div>
                 </div>
                 <div class="pdb-external-links">

--- a/src/modal/PdbDetailsModal.js
+++ b/src/modal/PdbDetailsModal.js
@@ -109,8 +109,8 @@ class PdbDetailsModal {
         if (authorList.length > 0) {
             fullAuthors = authorList.join(', ');
             displayAuthors = fullAuthors;
-            if (authorList.length > 4) {
-                displayAuthors = `${authorList.slice(0, 2).join(', ')}, ..., ${authorList.slice(-2).join(', ')}`;
+            if (authorList.length > 6) {
+                displayAuthors = `${authorList.slice(0, 3).join(', ')}, ..., ${authorList.slice(-3).join(', ')}`;
             }
         }
         const releaseDate = data.rcsb_accession_info?.initial_release_date ? new Date(data.rcsb_accession_info.initial_release_date).toLocaleDateString() : 'Not available';

--- a/style.css
+++ b/style.css
@@ -1429,6 +1429,8 @@ main {
 
 .pdb-info-value.authors-list {
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .pdb-info-value a {

--- a/style.css
+++ b/style.css
@@ -1427,6 +1427,10 @@ main {
     line-height: 1.4;
 }
 
+.pdb-info-value.authors-list {
+    white-space: nowrap;
+}
+
 .pdb-info-value a {
     color: #6e45e2;
     text-decoration: none;

--- a/style.css
+++ b/style.css
@@ -1380,8 +1380,8 @@ main {
 }
 
 .pdb-details-modal {
-    max-width: 900px;
-    width: 90%;
+    max-width: 1000px;
+    width: 95%;
 }
 
 .pdb-details-grid {
@@ -1431,6 +1431,30 @@ main {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    position: relative;
+}
+
+.pdb-info-value.authors-list .authors-tooltip {
+    visibility: hidden;
+    opacity: 0;
+    position: absolute;
+    left: 0;
+    top: 100%;
+    background: #333;
+    color: #fff;
+    padding: 6px;
+    border-radius: 4px;
+    white-space: normal;
+    z-index: 10;
+    width: max-content;
+    max-width: 400px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    transition: opacity 0.2s;
+}
+
+.pdb-info-value.authors-list:hover .authors-tooltip {
+    visibility: visible;
+    opacity: 1;
 }
 
 .pdb-info-value a {

--- a/tests/pdbDetailsModal.test.js
+++ b/tests/pdbDetailsModal.test.js
@@ -6,7 +6,7 @@ describe('PdbDetailsModal author truncation', () => {
   it('truncates long author lists and adds full list tooltip', () => {
     const data = {
       struct: { title: 'Test Title' },
-      citation: [{ rcsb_authors: ['Author1', 'Author2', 'Author3', 'Author4', 'Author5', 'Author6'] }],
+      citation: [{ rcsb_authors: ['Author1', 'Author2', 'Author3', 'Author4', 'Author5', 'Author6', 'Author7', 'Author8'] }],
       rcsb_accession_info: { initial_release_date: '2020-01-01' },
       rcsb_entry_info: { resolution_combined: [2.0] },
       exptl: [{ method: 'X-RAY' }],
@@ -14,7 +14,7 @@ describe('PdbDetailsModal author truncation', () => {
       rcsb_id: 'abcd'
     };
     const html = PdbDetailsModal.prototype.createPDBDetailsHTML(data);
-    assert.ok(html.includes('Author1, Author2, ..., Author5, Author6'));
-    assert.ok(html.includes('title="Author1, Author2, Author3, Author4, Author5, Author6"'));
+    assert.ok(html.includes('Author1, Author2, Author3, ..., Author6, Author7, Author8'));
+    assert.ok(html.includes('title="Author1, Author2, Author3, Author4, Author5, Author6, Author7, Author8"'));
   });
 });

--- a/tests/pdbDetailsModal.test.js
+++ b/tests/pdbDetailsModal.test.js
@@ -14,7 +14,7 @@ describe('PdbDetailsModal author truncation', () => {
       rcsb_id: 'abcd'
     };
     const html = PdbDetailsModal.prototype.createPDBDetailsHTML(data);
-    assert.ok(html.includes('Author1, Author2, Author3, ..., Author6, Author7, Author8'));
-    assert.ok(html.includes('title="Author1, Author2, Author3, Author4, Author5, Author6, Author7, Author8"'));
+    assert.ok(html.includes('Author1, Author2, ..., Author7, Author8'));
+    assert.ok(html.includes('<div class="authors-tooltip">Author1, Author2, Author3, Author4, Author5, Author6, Author7, Author8</div>'));
   });
 });

--- a/tests/pdbDetailsModal.test.js
+++ b/tests/pdbDetailsModal.test.js
@@ -1,0 +1,20 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import PdbDetailsModal from '../src/modal/PdbDetailsModal.js';
+
+describe('PdbDetailsModal author truncation', () => {
+  it('truncates long author lists and adds full list tooltip', () => {
+    const data = {
+      struct: { title: 'Test Title' },
+      citation: [{ rcsb_authors: ['Author1', 'Author2', 'Author3', 'Author4', 'Author5', 'Author6'] }],
+      rcsb_accession_info: { initial_release_date: '2020-01-01' },
+      rcsb_entry_info: { resolution_combined: [2.0] },
+      exptl: [{ method: 'X-RAY' }],
+      entity_src_gen: [{ pdbx_host_org_scientific_name: 'Org' }],
+      rcsb_id: 'abcd'
+    };
+    const html = PdbDetailsModal.prototype.createPDBDetailsHTML(data);
+    assert.ok(html.includes('Author1, Author2, ..., Author5, Author6'));
+    assert.ok(html.includes('title="Author1, Author2, Author3, Author4, Author5, Author6"'));
+  });
+});


### PR DESCRIPTION
## Summary
- Truncate long author lists in PDB details modal and show the full list in a tooltip
- Keep author list display on one line
- Add unit test for author truncation logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689108b23ae483298d9027bbb3cc2a3d