### PR TITLE
refactor: remove repository clearAll method

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -138,7 +138,7 @@ class MoleculeManager {
     }
 
     deleteAllMolecules() {
-        this.repository.clearAll();
+        this.repository.deleteAllMolecules();
         if (this.cardUI) {
             this.cardUI.clearAll();
         }

--- a/src/utils/MoleculeRepository.js
+++ b/src/utils/MoleculeRepository.js
@@ -59,10 +59,6 @@ class MoleculeRepository {
         return [...this.molecules];
     }
 
-    clearAll() {
-        this.molecules = [];
-    }
-
     removeHydrogensFromSdf(sdf) {
         const lines = sdf.split(/\r?\n/);
         if (lines.length < 4) return sdf;


### PR DESCRIPTION
## Summary
- remove deprecated clearAll from MoleculeRepository
- use deleteAllMolecules in main logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890cebf83dc8329b8d78e64f4439630