### PR TITLE
Refactor molecule card DOM setup

### DIFF
--- a/src/components/MoleculeCard.js
+++ b/src/components/MoleculeCard.js
@@ -10,7 +10,7 @@ class MoleculeCard {
         this.draggedElement = null;
     }
 
-    createMoleculeCardFromSmiles(smiles, ccdCode, id = ccdCode) {
+    createBaseCard(ccdCode, id = ccdCode, sdfData) {
         const card = document.createElement('div');
         card.className = 'molecule-card';
         card.draggable = true;
@@ -38,7 +38,7 @@ class MoleculeCard {
         downloadBtn.title = `Download ${ccdCode} as SDF`;
         downloadBtn.addEventListener('click', e => {
             e.stopPropagation();
-            this.downloadSdf(ccdCode);
+            this.downloadSdf(ccdCode, sdfData);
         });
         card.appendChild(downloadBtn);
 
@@ -51,6 +51,12 @@ class MoleculeCard {
             if (this.onCompare) this.onCompare(ccdCode);
         });
         card.appendChild(compareBtn);
+
+        return card;
+    }
+
+    createMoleculeCardFromSmiles(smiles, ccdCode, id = ccdCode) {
+        const card = this.createBaseCard(ccdCode, id);
 
         const codeLabel = document.createElement('div');
         codeLabel.className = 'molecule-code';
@@ -87,46 +93,7 @@ class MoleculeCard {
     }
 
     createMoleculeCard(data, ccdCode, format = 'sdf', id = ccdCode) {
-        const card = document.createElement('div');
-        card.className = 'molecule-card';
-        card.draggable = true;
-        card.setAttribute('data-molecule-code', ccdCode);
-        card.setAttribute('data-molecule-id', id);
-
-        const dragHandle = document.createElement('div');
-        dragHandle.className = 'drag-handle';
-        dragHandle.innerHTML = '⋯';
-        card.appendChild(dragHandle);
-
-        const deleteBtn = document.createElement('div');
-        deleteBtn.className = 'delete-btn';
-        deleteBtn.innerHTML = '<svg viewBox="0 0 24 24" width="16" height="16"><path fill="currentColor" d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"/></svg>';
-        deleteBtn.title = `Delete ${ccdCode}`;
-        deleteBtn.addEventListener('click', e => {
-            e.stopPropagation();
-            if (this.onDelete) this.onDelete(ccdCode);
-        });
-        card.appendChild(deleteBtn);
-
-        const downloadBtn = document.createElement('div');
-        downloadBtn.className = 'download-btn';
-        downloadBtn.innerHTML = '<svg viewBox="0 0 24 24" width="16" height="16"><path fill="currentColor" d="M5 20h14v-2H5m14-9h-4V3H9v6H5l7 7 7-7Z"/></svg>';
-        downloadBtn.title = `Download ${ccdCode} as SDF`;
-        downloadBtn.addEventListener('click', e => {
-            e.stopPropagation();
-            this.downloadSdf(ccdCode, data);
-        });
-        card.appendChild(downloadBtn);
-
-        const compareBtn = document.createElement('div');
-        compareBtn.className = 'compare-btn';
-        compareBtn.textContent = '⇆';
-        compareBtn.title = `Compare ${ccdCode}`;
-        compareBtn.addEventListener('click', e => {
-            e.stopPropagation();
-            if (this.onCompare) this.onCompare(ccdCode);
-        });
-        card.appendChild(compareBtn);
+        const card = this.createBaseCard(ccdCode, id, data);
 
         const title = document.createElement('h3');
         title.textContent = ccdCode;
@@ -162,36 +129,7 @@ class MoleculeCard {
     }
 
     createNotFoundCard(ccdCode, message = 'Not found', id = ccdCode) {
-        const card = document.createElement('div');
-        card.className = 'molecule-card';
-        card.draggable = true;
-        card.setAttribute('data-molecule-code', ccdCode);
-        card.setAttribute('data-molecule-id', id);
-
-        const dragHandle = document.createElement('div');
-        dragHandle.className = 'drag-handle';
-        dragHandle.innerHTML = '⋯';
-        card.appendChild(dragHandle);
-
-        const deleteBtn = document.createElement('div');
-        deleteBtn.className = 'delete-btn';
-        deleteBtn.innerHTML = '<svg viewBox="0 0 24 24" width="16" height="16"><path fill="currentColor" d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"/></svg>';
-        deleteBtn.title = `Delete ${ccdCode}`;
-        deleteBtn.addEventListener('click', e => {
-            e.stopPropagation();
-            if (this.onDelete) this.onDelete(ccdCode);
-        });
-        card.appendChild(deleteBtn);
-
-        const downloadBtn = document.createElement('div');
-        downloadBtn.className = 'download-btn';
-        downloadBtn.innerHTML = '<svg viewBox="0 0 24 24" width="16" height="16"><path fill="currentColor" d="M5 20h14v-2H5m14-9h-4V3H9v6H5l7 7 7-7Z"/></svg>';
-        downloadBtn.title = `Download ${ccdCode} as SDF`;
-        downloadBtn.addEventListener('click', e => {
-            e.stopPropagation();
-            this.downloadSdf(ccdCode);
-        });
-        card.appendChild(downloadBtn);
+        const card = this.createBaseCard(ccdCode, id);
 
         const content = document.createElement('div');
         content.className = 'not-found-content';
@@ -281,3 +219,4 @@ class MoleculeCard {
 }
 
 export default MoleculeCard;
+

--- a/tests/moleculeCard.test.js
+++ b/tests/moleculeCard.test.js
@@ -53,19 +53,19 @@ describe('MoleculeCard downloadSdf', () => {
 });
 
 describe('MoleculeCard compare button', () => {
-  it('adds a compare button and triggers callback on click', () => {
-    const makeEl = () => ({
-      style: {},
-      children: [],
-      appendChild(child) { this.children.push(child); return child; },
-      setAttribute: () => {},
-      addEventListener(type, handler) { this['on' + type] = handler; },
-      dispatchEvent(evt) { const h = this['on' + evt.type]; if (h) h(evt); },
-      innerHTML: '',
-      textContent: '',
-      className: ''
-    });
+  const makeEl = () => ({
+    style: {},
+    children: [],
+    appendChild(child) { this.children.push(child); return child; },
+    setAttribute: () => {},
+    addEventListener(type, handler) { this['on' + type] = handler; },
+    dispatchEvent(evt) { const h = this['on' + evt.type]; if (h) h(evt); },
+    innerHTML: '',
+    textContent: '',
+    className: ''
+  });
 
+  it('adds a compare button and triggers callback on createMoleculeCard', () => {
     global.document = { createElement: makeEl };
     global.window = {};
     global.$3Dmol = { createViewer: () => ({ addModel: () => {}, setStyle: () => {}, render: () => {}, zoomTo: () => {} }) };
@@ -85,6 +85,44 @@ describe('MoleculeCard compare button', () => {
 
     global.setTimeout = originalTimeout;
     delete global.$3Dmol;
+    delete global.document;
+    delete global.window;
+  });
+
+  it('adds a compare button for createMoleculeCardFromSmiles', () => {
+    global.document = { createElement: makeEl };
+    global.window = {};
+
+    const grid = makeEl();
+    const onCompare = mock.fn();
+    const cardUI = new MoleculeCard(grid, {}, { onCompare });
+    cardUI.createMoleculeCardFromSmiles('C', 'BBB');
+    const card = grid.children[0];
+    const compareBtn = card.children.find(c => c.className === 'compare-btn');
+    assert.ok(compareBtn);
+    compareBtn.dispatchEvent({ type: 'click', stopPropagation: () => {} });
+    assert.strictEqual(onCompare.mock.callCount(), 1);
+    assert.strictEqual(onCompare.mock.calls[0].arguments[0], 'BBB');
+
+    delete global.document;
+    delete global.window;
+  });
+
+  it('adds a compare button for createNotFoundCard', () => {
+    global.document = { createElement: makeEl };
+    global.window = {};
+
+    const grid = makeEl();
+    const onCompare = mock.fn();
+    const cardUI = new MoleculeCard(grid, {}, { onCompare });
+    cardUI.createNotFoundCard('CCC');
+    const card = grid.children[0];
+    const compareBtn = card.children.find(c => c.className === 'compare-btn');
+    assert.ok(compareBtn);
+    compareBtn.dispatchEvent({ type: 'click', stopPropagation: () => {} });
+    assert.strictEqual(onCompare.mock.callCount(), 1);
+    assert.strictEqual(onCompare.mock.calls[0].arguments[0], 'CCC');
+
     delete global.document;
     delete global.window;
   });


### PR DESCRIPTION
## Summary
- centralize core molecule card controls in new `createBaseCard` helper
- reuse base helper across SMILES, SDF and not-found card constructors
- extend tests to ensure compare control exists for all card types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890ceaac6708329a1fbe6aea68a37d1