### PR TITLE
feat: add SMILES search for CCDs

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
                     <h2>Molecular Database</h2>
                     <div class="header-buttons">
                         <button id="add-molecule-btn" class="add-btn" title="Add new molecule">+</button>
+                        <button id="smiles-search-open-btn" class="add-btn" title="Search by SMILES">🔍</button>
                         <button id="delete-all-btn" class="delete-all-btn" title="Delete all molecules">
                             <svg viewBox="0 0 24 24" width="18" height="18">
                                 <path fill="currentColor"
@@ -212,6 +213,20 @@
                     <button id="cancel-btn" class="btn-secondary">Cancel</button>
                     <button id="confirm-add-btn" class="btn-primary" disabled>Add Molecule</button>
                 </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="smiles-search-modal" class="modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3>Search by SMILES</h3>
+                <span class="close" id="close-smiles-modal">&times;</span>
+            </div>
+            <div class="modal-body">
+                <input type="text" id="smiles-input" placeholder="Enter SMILES">
+                <button id="smiles-submit-btn" class="btn-primary" style="margin-top:10px;">Search</button>
+                <div id="smiles-results" style="margin-top:15px;"></div>
             </div>
         </div>
     </div>

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ import LigandModal from './modal/LigandModal.js';
 import MoleculeCard from './components/MoleculeCard.js';
 import PdbDetailsModal from './modal/PdbDetailsModal.js';
 import AddMoleculeModal from './modal/AddMoleculeModal.js';
+import SmilesSearchModal from './modal/SmilesSearchModal.js';
 import ProteinBrowser from './components/ProteinBrowser.js';
 import ComparisonModal from './modal/ComparisonModal.js';
 
@@ -24,6 +25,7 @@ class MoleculeManager {
         this.boundLigandTable = null;
         this.pdbDetailsModal = null;
         this.addModal = null;
+        this.smilesSearchModal = null;
         this.comparisonModal = null;
         this.compareQueue = [];
     }
@@ -47,6 +49,7 @@ class MoleculeManager {
         );
         this.pdbDetailsModal = new PdbDetailsModal(this.boundLigandTable);
         this.addModal = new AddMoleculeModal(this);
+        this.smilesSearchModal = new SmilesSearchModal(this);
         this.comparisonModal = new ComparisonModal();
 
         document.getElementById('add-molecule-btn').addEventListener('click', () => {
@@ -54,6 +57,15 @@ class MoleculeManager {
                 this.addModal.open();
             }
         });
+
+        const smilesBtn = document.getElementById('smiles-search-open-btn');
+        if (smilesBtn) {
+            smilesBtn.addEventListener('click', () => {
+                if (this.smilesSearchModal) {
+                    this.smilesSearchModal.open();
+                }
+            });
+        }
 
         document.getElementById('delete-all-btn').addEventListener('click', () => {
             if (confirm('Delete all molecules?')) {

--- a/src/modal/SmilesSearchModal.js
+++ b/src/modal/SmilesSearchModal.js
@@ -1,0 +1,85 @@
+import ApiService from '../utils/apiService.js';
+
+class SmilesSearchModal {
+  constructor(moleculeManager) {
+    this.moleculeManager = moleculeManager;
+    this.modal = document.getElementById('smiles-search-modal');
+    this.input = document.getElementById('smiles-input');
+    this.searchBtn = document.getElementById('smiles-submit-btn');
+    this.results = document.getElementById('smiles-results');
+    this.closeBtn = document.getElementById('close-smiles-modal');
+
+    if (this.searchBtn) {
+      this.searchBtn.addEventListener('click', () => this.handleSearch());
+    }
+    if (this.closeBtn) {
+      this.closeBtn.addEventListener('click', () => this.close());
+    }
+    window.addEventListener('click', e => {
+      if (e.target === this.modal) {
+        this.close();
+      }
+    });
+  }
+
+  open() {
+    if (this.modal) {
+      this.reset();
+      this.modal.style.display = 'block';
+      this.input.focus();
+    }
+  }
+
+  close() {
+    if (this.modal) {
+      this.modal.style.display = 'none';
+    }
+  }
+
+  reset() {
+    if (this.input) this.input.value = '';
+    if (this.results) this.results.innerHTML = '';
+  }
+
+  async handleSearch() {
+    const smiles = this.input.value.trim();
+    if (!smiles) return;
+    if (this.results) this.results.innerHTML = 'Searching...';
+    try {
+      const hits = await ApiService.searchCcdsBySmiles(smiles);
+      if (!hits.length) {
+        this.results.innerHTML = '<p>No matches found</p>';
+        return;
+      }
+      const list = document.createElement('ul');
+      hits.forEach(hit => {
+        const li = document.createElement('li');
+        const score = Math.round((hit.score || 0) * 100);
+        li.textContent = `${hit.id} (${score}%) `;
+        const btn = document.createElement('button');
+        btn.textContent = '+';
+        btn.addEventListener('click', () => this.handleAdd(hit.id));
+        li.appendChild(btn);
+        list.appendChild(li);
+      });
+      this.results.innerHTML = '';
+      this.results.appendChild(list);
+    } catch (err) {
+      console.error('SMILES search failed:', err);
+      this.results.innerHTML = '<p class="error-text">Search failed</p>';
+    }
+  }
+
+  handleAdd(code) {
+    const success = this.moleculeManager.addMolecule(code);
+    if (typeof showNotification === 'function') {
+      if (success) {
+        showNotification(`Adding molecule ${code}...`, 'success');
+      } else {
+        showNotification(`Molecule ${code} already exists`, 'info');
+      }
+    }
+  }
+}
+
+export default SmilesSearchModal;

--- a/src/utils/apiService.js
+++ b/src/utils/apiService.js
@@ -115,10 +115,9 @@ export default class ApiService {
    * SMILES string and returns matching CCD codes with their similarity scores.
    *
    * @param {string} smiles - Query SMILES string.
-   * @param {number} [cutoff=0.6] - Similarity cutoff between 0 and 1.
    * @returns {Promise<Array<{id: string, score: number}>>} Array of results.
    */
-  static async searchCcdsBySmiles(smiles, cutoff = 0.6) {
+  static async searchCcdsBySmiles(smiles) {
     const body = {
       query: {
         type: 'terminal',
@@ -126,14 +125,10 @@ export default class ApiService {
         parameters: {
           value: smiles,
           type: 'descriptor',
-          descriptor_type: 'SMILES',
-          match_type: 'fingerprint-similarity',
-          similarity_cutoff: cutoff
+          descriptor_type: 'SMILES'
         }
       },
-      request_options: {
-        return_type: 'chem_comp'
-      }
+      return_type: 'mol_definition'
     };
 
     const response = await fetch(RCSB_SEARCH_API_URL, {

--- a/src/utils/apiService.js
+++ b/src/utils/apiService.js
@@ -125,10 +125,14 @@ export default class ApiService {
         parameters: {
           value: smiles,
           type: 'descriptor',
-          descriptor_type: 'SMILES'
+          descriptor_type: 'SMILES',
+          match_type: 'fingerprint-similarity',
+          similarity_cutoff: 0.6
         }
       },
-      return_type: 'mol_definition'
+      request_options: {
+        return_type: 'chem_comp'
+      }
     };
 
     const response = await fetch(RCSB_SEARCH_API_URL, {
@@ -143,9 +147,9 @@ export default class ApiService {
       throw error;
     }
     const data = await response.json();
-    return (data?.result_set || []).map(r => ({
-      id: r.identifier || r.chemid || r.chem_comp_id,
-      score: r.score
+    return (data?.result_set || []).map(({ identifier, score }) => ({
+      id: identifier,
+      score
     }));
   }
 

--- a/src/utils/apiService.js
+++ b/src/utils/apiService.js
@@ -12,6 +12,7 @@
 import {
   RCSB_LIGAND_BASE_URL,
   RCSB_MODEL_BASE_URL,
+  RCSB_SEARCH_API_URL,
   FRAGMENT_LIBRARY_URL,
   PD_BE_SIMILARITY_BASE_URL,
   PD_BE_IN_PDB_BASE_URL,
@@ -105,6 +106,52 @@ export default class ApiService {
     return this.fetchText(
       `${RCSB_LIGAND_BASE_URL}/${ccdCode.toUpperCase()}_ideal.sdf`
     );
+  }
+
+  /**
+   * Search Chemical Component Dictionary by SMILES string.
+   *
+   * Sends a similarity search request to RCSB's search API using the provided
+   * SMILES string and returns matching CCD codes with their similarity scores.
+   *
+   * @param {string} smiles - Query SMILES string.
+   * @param {number} [cutoff=0.6] - Similarity cutoff between 0 and 1.
+   * @returns {Promise<Array<{id: string, score: number}>>} Array of results.
+   */
+  static async searchCcdsBySmiles(smiles, cutoff = 0.6) {
+    const body = {
+      query: {
+        type: 'terminal',
+        service: 'chemical',
+        parameters: {
+          value: smiles,
+          type: 'descriptor',
+          descriptor_type: 'SMILES',
+          match_type: 'fingerprint-similarity',
+          similarity_cutoff: cutoff
+        }
+      },
+      request_options: {
+        return_type: 'chem_comp'
+      }
+    };
+
+    const response = await fetch(RCSB_SEARCH_API_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    });
+    if (!response.ok) {
+      const error = new Error(`HTTP error! status: ${response.status}`);
+      error.status = response.status;
+      error.url = RCSB_SEARCH_API_URL;
+      throw error;
+    }
+    const data = await response.json();
+    return (data?.result_set || []).map(r => ({
+      id: r.identifier || r.chemid || r.chem_comp_id,
+      score: r.score
+    }));
   }
 
   /**

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,5 +1,6 @@
 export const RCSB_LIGAND_BASE_URL = 'https://files.rcsb.org/ligands/view';
 export const RCSB_MODEL_BASE_URL = 'https://models.rcsb.org/v1';
+export const RCSB_SEARCH_API_URL = 'https://search.rcsb.org/rcsbsearch/v2/query';
 export const FRAGMENT_LIBRARY_URL = 'https://raw.githubusercontent.com/cch1999/cch1999.github.io/refs/heads/new_website/assets/files/fragment_library_ccd.tsv';
 export const PD_BE_SIMILARITY_BASE_URL = 'https://www.ebi.ac.uk/pdbe/graph-api/compound/similarity';
 export const PD_BE_IN_PDB_BASE_URL = 'https://www.ebi.ac.uk/pdbe/graph-api/compound/in_pdb';

--- a/tests/apiService.test.js
+++ b/tests/apiService.test.js
@@ -111,8 +111,11 @@ describe('ApiService', () => {
     const res = await ApiService.searchCcdsBySmiles('CCO');
     assert.strictEqual(global.fetch.mock.calls[0].arguments[0], RCSB_SEARCH_API_URL);
     const opts = global.fetch.mock.calls[0].arguments[1];
+    const body = JSON.parse(opts.body);
     assert.strictEqual(opts.method, 'POST');
-    assert.deepStrictEqual(JSON.parse(opts.body).query.parameters.value, 'CCO');
+    assert.strictEqual(body.return_type, 'mol_definition');
+    assert.strictEqual(body.query.parameters.descriptor_type, 'SMILES');
+    assert.strictEqual(body.query.parameters.value, 'CCO');
     assert.deepStrictEqual(res, [{ id: 'PAR', score: 0.8 }]);
   });
 

--- a/tests/apiService.test.js
+++ b/tests/apiService.test.js
@@ -4,7 +4,8 @@ import ApiService from '../src/utils/apiService.js';
 import {
   RCSB_LIGAND_BASE_URL,
   RCSB_MODEL_BASE_URL,
-  UNIPROT_ENTRY_BASE_URL
+  UNIPROT_ENTRY_BASE_URL,
+  RCSB_SEARCH_API_URL
 } from '../src/utils/constants.js';
 
 describe('ApiService', () => {
@@ -102,6 +103,17 @@ describe('ApiService', () => {
       global.fetch.mock.calls[0].arguments[0],
       `${UNIPROT_ENTRY_BASE_URL}/P12345.json`
     );
+  });
+
+  it('searchCcdsBySmiles posts query and maps results', async () => {
+    const mockData = { result_set: [{ identifier: 'PAR', score: 0.8 }] };
+    global.fetch = mock.fn(async () => ({ ok: true, json: async () => mockData }));
+    const res = await ApiService.searchCcdsBySmiles('CCO');
+    assert.strictEqual(global.fetch.mock.calls[0].arguments[0], RCSB_SEARCH_API_URL);
+    const opts = global.fetch.mock.calls[0].arguments[1];
+    assert.strictEqual(opts.method, 'POST');
+    assert.deepStrictEqual(JSON.parse(opts.body).query.parameters.value, 'CCO');
+    assert.deepStrictEqual(res, [{ id: 'PAR', score: 0.8 }]);
   });
 
   it('fetchText caches responses', async () => {

--- a/tests/apiService.test.js
+++ b/tests/apiService.test.js
@@ -113,8 +113,10 @@ describe('ApiService', () => {
     const opts = global.fetch.mock.calls[0].arguments[1];
     const body = JSON.parse(opts.body);
     assert.strictEqual(opts.method, 'POST');
-    assert.strictEqual(body.return_type, 'mol_definition');
+    assert.strictEqual(body.request_options.return_type, 'chem_comp');
     assert.strictEqual(body.query.parameters.descriptor_type, 'SMILES');
+    assert.strictEqual(body.query.parameters.match_type, 'fingerprint-similarity');
+    assert.strictEqual(body.query.parameters.similarity_cutoff, 0.6);
     assert.strictEqual(body.query.parameters.value, 'CCO');
     assert.deepStrictEqual(res, [{ id: 'PAR', score: 0.8 }]);
   });

--- a/tests/smilesSearchModal.test.js
+++ b/tests/smilesSearchModal.test.js
@@ -1,0 +1,64 @@
+import { describe, it, beforeEach, afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM, Element } from './domStub.js';
+import SmilesSearchModal from '../src/modal/SmilesSearchModal.js';
+import ApiService from '../src/utils/apiService.js';
+
+let dom;
+let manager;
+
+function setupDom() {
+  dom = new JSDOM();
+  const { document } = dom.window;
+  document.createElement = (tag) => {
+    const el = new Element(tag);
+    el.style = {};
+    el.addEventListener = () => {};
+    return el;
+  };
+  dom.window.addEventListener = () => {};
+  global.document = document;
+  global.window = dom.window;
+  global.showNotification = () => {};
+
+  const modal = document.createElement('div');
+  const input = document.createElement('input');
+  const searchBtn = document.createElement('button');
+  const results = document.createElement('div');
+  const closeBtn = document.createElement('span');
+
+  document.registerElement('smiles-search-modal', modal);
+  document.registerElement('smiles-input', input);
+  document.registerElement('smiles-submit-btn', searchBtn);
+  document.registerElement('smiles-results', results);
+  document.registerElement('close-smiles-modal', closeBtn);
+}
+
+describe('SmilesSearchModal', () => {
+  beforeEach(() => {
+    setupDom();
+    manager = { addMolecule: mock.fn(() => true) };
+  });
+  afterEach(() => {
+    mock.restoreAll();
+    delete global.document;
+    delete global.window;
+    delete global.showNotification;
+  });
+
+  it('searches and adds molecules from SMILES', async () => {
+    mock.method(ApiService, 'searchCcdsBySmiles', async () => [
+      { id: 'PAR', score: 0.9 }
+    ]);
+    const modal = new SmilesSearchModal(manager);
+    modal.input.value = 'CCO';
+    await modal.handleSearch();
+    const resEl = global.document.getElementById('smiles-results');
+    const ul = resEl.children[0];
+    const firstLi = ul && ul.children[0];
+    assert.ok(firstLi.textContent.includes('PAR'));
+    modal.handleAdd('PAR');
+    assert.strictEqual(manager.addMolecule.mock.callCount(), 1);
+    assert.deepStrictEqual(manager.addMolecule.mock.calls[0].arguments, ['PAR']);
+  });
+});


### PR DESCRIPTION
## Summary
- allow querying RCSB CCDs by SMILES via new ApiService method
- add SmilesSearchModal and UI button to add matches
- cover SMILES search with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891b5b3a090832989169d4d3e127a7f