### PR TITLE
feat: import fragment libraries from SDF

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,11 @@
             <div id="fragment-library-content" class="content-panel" style="display: none;">
                 <div class="database-header">
                     <h2>Fragment Library</h2>
-                    <button id="add-fragment-btn" class="add-btn" title="Add new fragment">+</button>
+                    <div class="header-buttons">
+                        <button id="add-fragment-btn" class="add-btn" title="Add new fragment">+</button>
+                        <button id="import-fragment-btn" class="add-btn" title="Import fragments from SDF">📁</button>
+                        <input type="file" id="fragment-sdf-input" accept=".sdf" style="display:none" />
+                    </div>
                 </div>
                 <div class="fragment-controls">
                     <input type="text" id="fragment-search" placeholder="Search fragments...">

--- a/tests/fragmentLibrary.test.js
+++ b/tests/fragmentLibrary.test.js
@@ -92,7 +92,7 @@ describe('FragmentLibrary', () => {
     assert.match(msg, /already exists/i);
   });
 
-  it('importFragmentsFromSdf parses and adds fragments', () => {
+  it('importFragmentsFromSdf parses and adds fragments and source option', () => {
     library.fragments = [];
     library.renderFragments = () => {};
     const sdf = `Frag1\nM  END\n$$$$\nFrag2\nM  END\n$$$$`;
@@ -101,6 +101,7 @@ describe('FragmentLibrary', () => {
     assert.strictEqual(library.fragments.length, 2);
     assert.strictEqual(library.fragments[0].source, 'SDFLIB');
     assert.strictEqual(library.fragments[0].kind, 'SDF');
+    assert.ok(library.sourceFilter.children.some(o => o.value === 'SDFLIB'));
   });
 
   it('renderFragments filters by search text, source filter, and CCD toggle', () => {
@@ -134,5 +135,20 @@ describe('FragmentLibrary', () => {
     library.renderFragments();
     assert.strictEqual(library.grid.children.length, 1);
     assert.match(library.grid.textContent, /Beta/);
+  });
+
+  it('renderFragments can search by library name', () => {
+    library.fragments = [
+      { id: '1', name: 'FragA', source: 'LibOne', in_ccd: false, kind: 'OTHER', query: '' },
+      { id: '2', name: 'FragB', source: 'LibTwo', in_ccd: false, kind: 'OTHER', query: '' }
+    ];
+
+    library.searchInput.value = 'libone';
+    library.sourceFilter.value = 'all';
+    library.ccdToggle.checked = false;
+    library.renderFragments();
+
+    assert.strictEqual(library.grid.children.length, 1);
+    assert.match(library.grid.textContent, /FragA/);
   });
 });

--- a/tests/fragmentLibrary.test.js
+++ b/tests/fragmentLibrary.test.js
@@ -92,6 +92,17 @@ describe('FragmentLibrary', () => {
     assert.match(msg, /already exists/i);
   });
 
+  it('importFragmentsFromSdf parses and adds fragments', () => {
+    library.fragments = [];
+    library.renderFragments = () => {};
+    const sdf = `Frag1\nM  END\n$$$$\nFrag2\nM  END\n$$$$`;
+    const count = library.importFragmentsFromSdf(sdf, 'SDFLIB');
+    assert.strictEqual(count, 2);
+    assert.strictEqual(library.fragments.length, 2);
+    assert.strictEqual(library.fragments[0].source, 'SDFLIB');
+    assert.strictEqual(library.fragments[0].kind, 'SDF');
+  });
+
   it('renderFragments filters by search text, source filter, and CCD toggle', () => {
     library.fragments = [
       { id: '1', name: 'Alpha', source: 'custom', in_ccd: false, kind: 'OTHER', query: '' },


### PR DESCRIPTION
## Summary
- allow importing fragment libraries from SDF files in the Fragment Library UI
- render SDF fragments and parse SDF records into custom entries
- test SDF import functionality

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891b772ecc08329b40698b678fcdbb4