### PR TITLE
feat: add enzyme design tab with sequence analysis

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
             <button class="tab-button active">Molecules</button>
             <button class="tab-button">Fragments</button>
             <button class="tab-button">Proteins</button>
+            <button class="tab-button">Enzymes</button>
         </div>
         <div class="content">
             <div id="molecule-library-content" class="content-panel">
@@ -152,6 +153,16 @@
                     <p id="no-protein-results-message" style="display: none;">No results found.</p>
                     <div class="loading-indicator" id="protein-loading-indicator" style="display: none;">Loading protein
                         data...</div>
+                </div>
+            </div>
+            <div id="enzyme-design-content" class="content-panel" style="display: none;">
+                <div class="database-header">
+                    <h2>Enzyme Design</h2>
+                </div>
+                <div class="enzyme-controls">
+                    <textarea id="enzyme-sequence-input" rows="4" placeholder="Enter amino acid sequence..."></textarea>
+                    <button id="analyze-sequence-btn" class="action-btn">Analyze Sequence</button>
+                    <div id="sequence-analysis-result"></div>
                 </div>
             </div>
         </div>

--- a/src/components/EnzymeDesigner.js
+++ b/src/components/EnzymeDesigner.js
@@ -1,0 +1,54 @@
+class EnzymeDesigner {
+    constructor() {
+        this.sequenceInput = null;
+        this.analyzeBtn = null;
+        this.resultContainer = null;
+    }
+
+    init() {
+        this.sequenceInput = document.getElementById('enzyme-sequence-input');
+        this.analyzeBtn = document.getElementById('analyze-sequence-btn');
+        this.resultContainer = document.getElementById('sequence-analysis-result');
+
+        if (this.analyzeBtn) {
+            this.analyzeBtn.addEventListener('click', () => {
+                const seq = (this.sequenceInput.value || '').trim().toUpperCase();
+                const result = EnzymeDesigner.analyzeSequence(seq);
+                if (!result) {
+                    this.resultContainer.innerHTML = '<p>Invalid sequence.</p>';
+                    return;
+                }
+                const compList = Object.entries(result.composition)
+                    .map(([aa, count]) => `<li>${aa}: ${count}</li>`)
+                    .join('');
+                this.resultContainer.innerHTML = `
+                    <p>Length: ${result.length}</p>
+                    <p>Molecular Weight: ${result.molecularWeight.toFixed(2)} Da</p>
+                    <ul>${compList}</ul>
+                `;
+            });
+        }
+        return this;
+    }
+
+    static analyzeSequence(seq) {
+        if (!seq || /[^ACDEFGHIKLMNPQRSTVWY]/i.test(seq)) {
+            return null;
+        }
+        const weights = {
+            A: 89.09, C: 121.15, D: 133.10, E: 147.13, F: 165.19,
+            G: 75.07, H: 155.16, I: 131.17, K: 146.19, L: 131.17,
+            M: 149.21, N: 132.12, P: 115.13, Q: 146.15, R: 174.20,
+            S: 105.09, T: 119.12, V: 117.15, W: 204.23, Y: 181.19
+        };
+        let weight = 18.015; // add weight of water
+        const composition = {};
+        for (const aa of seq) {
+            weight += weights[aa];
+            composition[aa] = (composition[aa] || 0) + 1;
+        }
+        return { length: seq.length, molecularWeight: weight, composition };
+    }
+}
+
+export default EnzymeDesigner;

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ import PdbDetailsModal from './modal/PdbDetailsModal.js';
 import AddMoleculeModal from './modal/AddMoleculeModal.js';
 import ProteinBrowser from './components/ProteinBrowser.js';
 import ComparisonModal from './modal/ComparisonModal.js';
+import EnzymeDesigner from './components/EnzymeDesigner.js';
 
 class MoleculeManager {
     constructor() {
@@ -25,6 +26,7 @@ class MoleculeManager {
         this.pdbDetailsModal = null;
         this.addModal = null;
         this.comparisonModal = null;
+        this.enzymeDesigner = null;
         this.compareQueue = [];
     }
 
@@ -48,6 +50,7 @@ class MoleculeManager {
         this.pdbDetailsModal = new PdbDetailsModal(this.boundLigandTable);
         this.addModal = new AddMoleculeModal(this);
         this.comparisonModal = new ComparisonModal();
+        this.enzymeDesigner = new EnzymeDesigner().init();
 
         document.getElementById('add-molecule-btn').addEventListener('click', () => {
             if (this.addModal) {
@@ -102,7 +105,8 @@ class MoleculeManager {
         const panels = [
             document.getElementById('molecule-library-content'),
             document.getElementById('fragment-library-content'),
-            document.getElementById('protein-browser-content')
+            document.getElementById('protein-browser-content'),
+            document.getElementById('enzyme-design-content')
         ];
         tabButtons.forEach((button, index) => {
             button.addEventListener('click', () => {

--- a/style.css
+++ b/style.css
@@ -118,6 +118,29 @@ main {
     min-width: 200px;
 }
 
+.enzyme-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    max-width: 400px;
+    margin-bottom: 20px;
+}
+
+#enzyme-sequence-input {
+    padding: 8px 12px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-family: monospace;
+}
+
+#sequence-analysis-result {
+    margin-top: 10px;
+    background-color: #f9f9f9;
+    padding: 10px;
+    border-radius: 8px;
+    font-size: 14px;
+}
+
 .fragment-card {
     display: flex;
     flex-direction: column;

--- a/tests/enzymeDesigner.test.js
+++ b/tests/enzymeDesigner.test.js
@@ -1,0 +1,19 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import EnzymeDesigner from '../src/components/EnzymeDesigner.js';
+
+describe('EnzymeDesigner', () => {
+  it('analyzeSequence computes properties', () => {
+    const res = EnzymeDesigner.analyzeSequence('ACD');
+    assert.ok(res);
+    assert.strictEqual(res.length, 3);
+    assert.ok(Math.abs(res.molecularWeight - 361.35) < 0.1);
+    assert.strictEqual(res.composition.A, 1);
+    assert.strictEqual(res.composition.C, 1);
+    assert.strictEqual(res.composition.D, 1);
+  });
+
+  it('analyzeSequence rejects invalid characters', () => {
+    assert.strictEqual(EnzymeDesigner.analyzeSequence('ABZ'), null);
+  });
+});


### PR DESCRIPTION
## Summary
- add new Enzymes tab to explore basic enzyme design
- analyze protein sequences for length, weight, and composition
- include unit tests for new EnzymeDesigner utility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898c587f5d48329be102a82cb395b2c