### PR TITLE
feat: introduce split pane molecule workspace

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,26 +49,59 @@
         </div>
         <div class="content">
             <div id="molecule-library-content" class="content-panel">
-                <div class="database-header">
-                    <h2>Molecular Database</h2>
-                    <div class="header-buttons">
-                        <button id="add-molecule-btn" class="add-btn" title="Add new molecule">+</button>
-                        <button id="delete-all-btn" class="delete-all-btn" title="Delete all molecules">
-                            <svg viewBox="0 0 24 24" width="18" height="18">
-                                <path fill="currentColor"
-                                    d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z" />
-                            </svg>
-                        </button>
-                        <button id="export-btn" class="export-btn" title="Export all molecules">
-                            <svg viewBox="0 0 24 24" width="18" height="18">
-                                <path fill="currentColor"
-                                    d="M5 20h14v-2H5m14-9h-4V3H9v6H5l7 7 7-7Z" />
-                            </svg>
-                        </button>
-                    </div>
-                </div>
-                <div id="molecule-grid" class="molecule-grid">
-                    <div class="loading-indicator">Loading molecules...</div>
+                <div id="workspace" class="split-pane">
+                    <aside id="sidebar" class="sidebar">
+                        <div class="sidebar-toolbar">
+                            <input type="text" id="molecule-search" placeholder="Search molecules..." />
+                            <button id="add-molecule-btn" class="add-btn" title="Add new molecule">+</button>
+                            <button id="delete-all-btn" class="delete-all-btn" title="Delete all molecules">
+                                <svg viewBox="0 0 24 24" width="18" height="18">
+                                    <path fill="currentColor" d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z" />
+                                </svg>
+                            </button>
+                            <button id="export-btn" class="export-btn" title="Export all molecules">
+                                <svg viewBox="0 0 24 24" width="18" height="18">
+                                    <path fill="currentColor" d="M5 20h14v-2H5m14-9h-4V3H9v6H5l7 7 7-7Z" />
+                                </svg>
+                            </button>
+                        </div>
+                        <div id="molecule-grid" class="molecule-list">
+                            <div class="loading-indicator">Loading molecules...</div>
+                        </div>
+                    </aside>
+                    <div id="splitter" class="splitter"></div>
+                    <section id="molecule-details" class="details-pane">
+                        <div class="details-toolbar">
+                            <button id="sidebar-toggle" class="mobile-only">☰</button>
+                            <button id="detail-refresh" title="Refresh">⟳</button>
+                            <button id="detail-download" title="Download">⬇</button>
+                            <button id="detail-copy" title="Copy">📋</button>
+                            <button id="detail-pdbe" title="Open in PDBe">PDBe</button>
+                            <button id="detail-rcsb" title="Open in RCSB">RCSB</button>
+                        </div>
+                        <div class="details-content">
+                            <div class="details-section" id="info-section">
+                                <h3 class="section-header">Info</h3>
+                                <div class="section-body"></div>
+                            </div>
+                            <div class="details-section" id="two-d-section">
+                                <h3 class="section-header">2D</h3>
+                                <div class="section-body"></div>
+                            </div>
+                            <div class="details-section" id="three-d-section">
+                                <h3 class="section-header">3D</h3>
+                                <div class="section-body"></div>
+                            </div>
+                            <div class="details-section" id="similar-section">
+                                <h3 class="section-header">Similar</h3>
+                                <div class="section-body"></div>
+                            </div>
+                            <div class="details-section" id="pdb-section">
+                                <h3 class="section-header">PDB</h3>
+                                <div class="section-body"></div>
+                            </div>
+                        </div>
+                    </section>
                 </div>
             </div>
             <div id="fragment-library-content" class="content-panel" style="display: none;">

--- a/src/main.js
+++ b/src/main.js
@@ -362,3 +362,52 @@ function initThemeToggle() {
 }
 
 initThemeToggle();
+
+// Initialize split-pane interactions
+setupSplitPane();
+initDetailSections();
+initSidebarToggle();
+
+function setupSplitPane() {
+    const workspace = document.getElementById('workspace');
+    const sidebar = document.getElementById('sidebar');
+    const splitter = document.getElementById('splitter');
+    if (!workspace || !sidebar || !splitter) return;
+    let startX = 0;
+    let startWidth = 0;
+
+    const onMouseMove = (e) => {
+        const newWidth = Math.max(200, startWidth + (e.clientX - startX));
+        workspace.style.gridTemplateColumns = `${newWidth}px 4px 1fr`;
+    };
+
+    const stopResize = () => {
+        document.removeEventListener('mousemove', onMouseMove);
+        document.removeEventListener('mouseup', stopResize);
+    };
+
+    splitter.addEventListener('mousedown', (e) => {
+        startX = e.clientX;
+        startWidth = sidebar.offsetWidth;
+        document.addEventListener('mousemove', onMouseMove);
+        document.addEventListener('mouseup', stopResize);
+    });
+}
+
+function initDetailSections() {
+    document.querySelectorAll('.details-section .section-header').forEach(header => {
+        header.addEventListener('click', () => {
+            const section = header.parentElement;
+            section.classList.toggle('collapsed');
+        });
+    });
+}
+
+function initSidebarToggle() {
+    const sidebar = document.getElementById('sidebar');
+    const toggle = document.getElementById('sidebar-toggle');
+    if (!sidebar || !toggle) return;
+    toggle.addEventListener('click', () => {
+        sidebar.classList.toggle('open');
+    });
+}

--- a/style.css
+++ b/style.css
@@ -198,6 +198,141 @@ main {
     visibility: hidden;
 }
 
+/* Split-pane layout */
+#workspace.split-pane {
+    display: grid;
+    grid-template-columns: 320px 4px 1fr;
+    height: calc(100vh - 160px);
+    /* adjust based on header */
+}
+
+.sidebar {
+    overflow-y: auto;
+    background: #fff;
+    border-right: 1px solid #ddd;
+    display: flex;
+    flex-direction: column;
+}
+
+.sidebar-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px;
+    border-bottom: 1px solid #eee;
+}
+
+.sidebar-toolbar input[type="text"] {
+    flex: 1;
+    padding: 6px 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+.splitter {
+    width: 4px;
+    cursor: col-resize;
+    background: #eee;
+}
+
+.details-pane {
+    overflow-y: auto;
+    background: #fafafa;
+    position: relative;
+}
+
+.details-toolbar {
+    display: flex;
+    gap: 8px;
+    padding: 8px;
+    position: sticky;
+    top: 0;
+    background: #fafafa;
+    border-bottom: 1px solid #ddd;
+    z-index: 10;
+}
+
+.details-section {
+    border-bottom: 1px solid #e0e0e0;
+}
+
+.details-section .section-header {
+    margin: 0;
+    padding: 12px;
+    cursor: pointer;
+    font-size: 16px;
+    background: #f0f0f0;
+}
+
+.details-section .section-body {
+    padding: 12px;
+}
+
+.details-section.collapsed .section-body {
+    display: none;
+}
+
+/* Mobile responsive */
+@media (max-width: 768px) {
+    #workspace.split-pane {
+        grid-template-columns: 0 0 1fr;
+    }
+    .sidebar {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 80%;
+        max-width: 320px;
+        transform: translateX(-100%);
+        transition: transform 0.3s ease;
+        z-index: 1000;
+        box-shadow: 2px 0 5px rgba(0,0,0,0.3);
+    }
+    .sidebar.open {
+        transform: translateX(0);
+    }
+    .splitter {
+        display: none;
+    }
+    .mobile-only {
+        display: inline-block;
+    }
+}
+
+.mobile-only {
+    display: none;
+}
+
+/* Compact molecule list */
+.molecule-list {
+    display: flex;
+    flex-direction: column;
+    padding: 0;
+}
+
+.molecule-list .molecule-card {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 8px;
+    border-bottom: 1px solid #eee;
+}
+
+.molecule-list .molecule-card:hover {
+    background: #f5f5f5;
+}
+
+.molecule-list .card-actions {
+    margin-left: auto;
+    display: none;
+    gap: 4px;
+}
+
+.molecule-list .molecule-card:hover .card-actions {
+    display: flex;
+}
+
 .toggle-switch-label {
     cursor: pointer;
     text-indent: -9999px;


### PR DESCRIPTION
## Summary
- switch molecule layout to split pane with sidebar list and persistent details view
- add draggable splitter and responsive drawer on small screens
- implement collapsible detail sections with sticky toolbar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898ee3dfbc08329a5bce62d5a02ee11