### PR TITLE
Add research notebook scaffolding with notes and timeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,9 @@
                                     d="M5 20h14v-2H5m14-9h-4V3H9v6H5l7 7 7-7Z" />
                             </svg>
                         </button>
+                        <button id="export-session-btn" class="export-btn" title="Export notebook session">
+                            <span class="material-icons">description</span>
+                        </button>
                     </div>
                 </div>
                 <div id="molecule-grid" class="molecule-grid">
@@ -210,6 +213,35 @@
             </div>
         </div>
     </main>
+
+    <div id="notes-panel" class="notes-panel collapsed">
+        <div class="notes-header">
+            <h3>Notes</h3>
+            <button id="notes-toggle" class="collapse-btn">&lt;</button>
+        </div>
+        <div class="notes-content">
+            <div class="notes-toolbar">
+                <button data-md="bold"><b>B</b></button>
+                <button data-md="italic"><i>I</i></button>
+                <button data-md="ul">&#8226;</button>
+            </div>
+            <textarea id="notes-editor" placeholder="Write notes..."></textarea>
+            <input type="text" id="notes-tags" placeholder="Tags (comma separated)">
+            <button id="snapshot-btn" class="action-btn">Add Snapshot</button>
+            <div id="snapshot-container" class="snapshot-container"></div>
+        </div>
+    </div>
+
+    <div id="timeline-dock" class="timeline-dock collapsed">
+        <div class="timeline-header">
+            <span>Timeline</span>
+            <button id="timeline-toggle" class="collapse-btn">▲</button>
+        </div>
+        <div class="timeline-content">
+            <input type="text" id="timeline-filter" placeholder="Filter actions...">
+            <ul id="timeline-list" class="timeline-list"></ul>
+        </div>
+    </div>
 
     <!-- Add Fragment Modal -->
     <div id="add-fragment-modal" class="modal">
@@ -410,6 +442,7 @@
       "formula": null
     }
 }</pre>
+                        <button id="copy-json-btn" class="copy-btn">Copy JSON</button>
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -429,6 +429,11 @@
                 </div>
 
                 <div class="details-section">
+                    <h4>Notes</h4>
+                    <textarea id="details-notes" placeholder="Write notes about this molecule..."></textarea>
+                </div>
+
+                <div class="details-section">
                     <h4>JSON Representation</h4>
                     <div class="json-container">
                         <pre id="details-json">{

--- a/src/components/Notebook.js
+++ b/src/components/Notebook.js
@@ -1,0 +1,130 @@
+class Notebook {
+    constructor(moleculeManager) {
+        this.moleculeManager = moleculeManager;
+        this.notesPanel = document.getElementById('notes-panel');
+        this.notesToggle = document.getElementById('notes-toggle');
+        this.notesEditor = document.getElementById('notes-editor');
+        this.tagsInput = document.getElementById('notes-tags');
+        this.snapshotBtn = document.getElementById('snapshot-btn');
+        this.snapshotContainer = document.getElementById('snapshot-container');
+        this.timelineDock = document.getElementById('timeline-dock');
+        this.timelineList = document.getElementById('timeline-list');
+        this.timelineToggle = document.getElementById('timeline-toggle');
+        this.timelineFilter = document.getElementById('timeline-filter');
+        this.exportBtn = document.getElementById('export-session-btn');
+        this.currentMolecule = null;
+        this.tags = {};
+        this.snapshots = [];
+        this.timeline = [];
+
+        if (this.notesToggle) {
+            this.notesToggle.addEventListener('click', () => {
+                this.notesPanel.classList.toggle('collapsed');
+            });
+        }
+        if (this.timelineToggle) {
+            this.timelineToggle.addEventListener('click', () => {
+                this.timelineDock.classList.toggle('collapsed');
+            });
+        }
+        if (this.tagsInput) {
+            this.tagsInput.addEventListener('change', () => this.saveTags());
+        }
+        if (this.snapshotBtn) {
+            this.snapshotBtn.addEventListener('click', () => this.captureSnapshot());
+        }
+        if (this.timelineFilter) {
+            this.timelineFilter.addEventListener('input', () => this.renderTimeline());
+        }
+        if (this.exportBtn) {
+            this.exportBtn.addEventListener('click', () => this.exportSession());
+        }
+    }
+
+    setCurrentMolecule(code) {
+        this.currentMolecule = code;
+        const tags = this.tags[code] || [];
+        if (this.tagsInput) this.tagsInput.value = tags.join(', ');
+    }
+
+    saveTags() {
+        if (!this.currentMolecule) return;
+        const tags = this.tagsInput.value
+            .split(',')
+            .map(t => t.trim())
+            .filter(Boolean);
+        this.tags[this.currentMolecule] = tags;
+    }
+
+    logAction(action, thumbnail) {
+        const entry = {
+            action,
+            time: new Date().toISOString(),
+            thumbnail
+        };
+        this.timeline.push(entry);
+        this.renderTimeline();
+    }
+
+    renderTimeline() {
+        if (!this.timelineList) return;
+        const filter = this.timelineFilter?.value?.toLowerCase() || '';
+        this.timelineList.innerHTML = '';
+        this.timeline
+            .filter(e => e.action.toLowerCase().includes(filter))
+            .forEach(e => {
+                const li = document.createElement('li');
+                li.className = 'timeline-item';
+                if (e.thumbnail) {
+                    const img = document.createElement('img');
+                    img.src = e.thumbnail;
+                    img.alt = '';
+                    li.appendChild(img);
+                }
+                const span = document.createElement('span');
+                span.textContent = `${new Date(e.time).toLocaleTimeString()} - ${e.action}`;
+                li.appendChild(span);
+                this.timelineList.appendChild(li);
+            });
+    }
+
+    captureSnapshot() {
+        const canvas = document.querySelector('.details-viewer canvas, .molecule-viewer canvas, .viewer-container canvas');
+        if (!canvas) return;
+        const dataURL = canvas.toDataURL('image/png');
+        this.snapshots.push({ image: dataURL, note: this.notesEditor ? this.notesEditor.value : '' });
+        if (this.snapshotContainer) {
+            const img = document.createElement('img');
+            img.src = dataURL;
+            img.className = 'snapshot-thumb';
+            this.snapshotContainer.appendChild(img);
+        }
+        this.logAction('Snapshot captured', dataURL);
+    }
+
+    exportSession() {
+        const data = {
+            molecules: this.moleculeManager?.getAllMolecules ? this.moleculeManager.getAllMolecules() : [],
+            notes: this.notesEditor ? this.notesEditor.value : '',
+            tags: this.tags,
+            snapshots: this.snapshots,
+            timeline: this.timeline,
+            layout: {
+                notesCollapsed: this.notesPanel?.classList.contains('collapsed'),
+                timelineCollapsed: this.timelineDock?.classList.contains('collapsed')
+            }
+        };
+        const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'session.json';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    }
+}
+
+export default Notebook;
+

--- a/src/components/Notebook.js
+++ b/src/components/Notebook.js
@@ -14,6 +14,7 @@ class Notebook {
         this.exportBtn = document.getElementById('export-session-btn');
         this.currentMolecule = null;
         this.tags = {};
+        this.notes = {};
         this.snapshots = [];
         this.timeline = [];
 
@@ -30,6 +31,9 @@ class Notebook {
         if (this.tagsInput) {
             this.tagsInput.addEventListener('change', () => this.saveTags());
         }
+        if (this.notesEditor) {
+            this.notesEditor.addEventListener('input', () => this.saveNote());
+        }
         if (this.snapshotBtn) {
             this.snapshotBtn.addEventListener('click', () => this.captureSnapshot());
         }
@@ -45,6 +49,7 @@ class Notebook {
         this.currentMolecule = code;
         const tags = this.tags[code] || [];
         if (this.tagsInput) this.tagsInput.value = tags.join(', ');
+        if (this.notesEditor) this.notesEditor.value = this.notes[code] || '';
     }
 
     saveTags() {
@@ -54,6 +59,22 @@ class Notebook {
             .map(t => t.trim())
             .filter(Boolean);
         this.tags[this.currentMolecule] = tags;
+    }
+
+    saveNote() {
+        if (!this.currentMolecule || !this.notesEditor) return;
+        this.notes[this.currentMolecule] = this.notesEditor.value;
+    }
+
+    getNote(code) {
+        return this.notes[code] || '';
+    }
+
+    setNoteForMolecule(code, note) {
+        this.notes[code] = note;
+        if (this.currentMolecule === code && this.notesEditor) {
+            this.notesEditor.value = note;
+        }
     }
 
     logAction(action, thumbnail) {
@@ -105,7 +126,7 @@ class Notebook {
     exportSession() {
         const data = {
             molecules: this.moleculeManager?.getAllMolecules ? this.moleculeManager.getAllMolecules() : [],
-            notes: this.notesEditor ? this.notesEditor.value : '',
+            notes: this.notes,
             tags: this.tags,
             snapshots: this.snapshots,
             timeline: this.timeline,

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@ import AddMoleculeModal from './modal/AddMoleculeModal.js';
 import ProteinBrowser from './components/ProteinBrowser.js';
 import PyMolInterface from './components/PyMolInterface.js';
 import ComparisonModal from './modal/ComparisonModal.js';
+import Notebook from './components/Notebook.js';
 
 class MoleculeManager {
     constructor() {
@@ -26,6 +27,7 @@ class MoleculeManager {
         this.pdbDetailsModal = null;
         this.addModal = null;
         this.comparisonModal = null;
+        this.notebook = null;
         this.compareQueue = [];
     }
 
@@ -49,6 +51,7 @@ class MoleculeManager {
         this.pdbDetailsModal = new PdbDetailsModal(this.boundLigandTable);
         this.addModal = new AddMoleculeModal(this);
         this.comparisonModal = new ComparisonModal();
+        this.notebook = new Notebook(this);
 
         document.getElementById('add-molecule-btn').addEventListener('click', () => {
             if (this.addModal) {
@@ -126,6 +129,7 @@ class MoleculeManager {
         const added = this.repository.addMolecule(molecule);
         if (added) {
             this.loader.loadMolecule(molecule);
+            window.notebook?.logAction(`Added molecule ${molecule.code}`);
         }
         return added;
     }
@@ -195,6 +199,10 @@ class MoleculeManager {
     }
 
     showMoleculeDetails(ccdCode, data, format) {
+        if (window.notebook) {
+            window.notebook.setCurrentMolecule(ccdCode);
+            window.notebook.logAction(`Viewed ${ccdCode}`);
+        }
         if (this.ligandModal) {
             this.ligandModal.show(ccdCode, data, format);
         }
@@ -289,6 +297,7 @@ if (confirmAddFragmentBtn) {
 
 const proteinBrowser = new ProteinBrowser(moleculeManager).init();
 const pyMolInterface = new PyMolInterface().init();
+const notebook = moleculeManager.notebook;
 
 function showNotification(message, type = 'info') {
     const notification = document.createElement('div');
@@ -334,6 +343,7 @@ window.moleculeManager = moleculeManager;
 window.fragmentLibrary = fragmentLibrary;
 window.proteinBrowser = proteinBrowser;
 window.pyMolInterface = pyMolInterface;
+window.notebook = notebook;
 window.showNotification = showNotification;
 
 function toggleDarkMode() {

--- a/src/modal/LigandDetails.js
+++ b/src/modal/LigandDetails.js
@@ -15,6 +15,7 @@ class LigandDetails {
         this.detailsResidue = document.getElementById('details-residue');
         this.detailsViewer = document.getElementById('details-viewer-container');
         this.detailsJSON = document.getElementById('details-json');
+        this.copyBtn = document.getElementById('copy-json-btn');
         this.viewer = null;
 
         const closeBtn = document.getElementById('close-details-modal');
@@ -26,6 +27,26 @@ class LigandDetails {
                 this.close();
             }
         });
+
+        if (this.copyBtn) {
+            this.copyBtn.addEventListener('click', () => {
+                const text = this.detailsJSON ? this.detailsJSON.textContent : '';
+                if (navigator.clipboard && text) {
+                    navigator.clipboard.writeText(text).then(() => {
+                        if (typeof showNotification === 'function') {
+                            showNotification('JSON copied to clipboard', 'success');
+                        }
+                    }).catch(() => {});
+                } else if (text) {
+                    const area = document.createElement('textarea');
+                    area.value = text;
+                    document.body.appendChild(area);
+                    area.select();
+                    document.execCommand('copy');
+                    document.body.removeChild(area);
+                }
+            });
+        }
     }
 
     show(ccdCode, sdfData) {

--- a/src/modal/LigandDetails.js
+++ b/src/modal/LigandDetails.js
@@ -16,6 +16,7 @@ class LigandDetails {
         this.detailsViewer = document.getElementById('details-viewer-container');
         this.detailsJSON = document.getElementById('details-json');
         this.copyBtn = document.getElementById('copy-json-btn');
+        this.detailsNotes = document.getElementById('details-notes');
         this.viewer = null;
 
         const closeBtn = document.getElementById('close-details-modal');
@@ -73,9 +74,15 @@ class LigandDetails {
               if (this.detailsChain) this.detailsChain.textContent = molecule.chainId;
               if (this.detailsResidue) this.detailsResidue.textContent = molecule.authorResidueNumber;
         } else {
-            if (this.detailsPdbId) this.detailsPdbId.textContent = '-';
-            if (this.detailsChain) this.detailsChain.textContent = '-';
-            if (this.detailsResidue) this.detailsResidue.textContent = '-';
+        if (this.detailsPdbId) this.detailsPdbId.textContent = '-';
+        if (this.detailsChain) this.detailsChain.textContent = '-';
+        if (this.detailsResidue) this.detailsResidue.textContent = '-';
+        }
+
+        if (this.detailsNotes) {
+            const note = window.notebook?.getNote(ccdCode) || '';
+            this.detailsNotes.value = note;
+            this.detailsNotes.oninput = () => window.notebook?.setNoteForMolecule(ccdCode, this.detailsNotes.value);
         }
 
         this.detailsViewer.innerHTML = '<p>Loading structure...</p>';

--- a/style.css
+++ b/style.css
@@ -1798,3 +1798,127 @@ body.dark-mode .molecule-viewer,
 body.dark-mode .details-viewer {
     background: #e0e0e0;
 }
+
+/* Research Notebook */
+.notes-panel {
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 300px;
+    height: 100%;
+    background: #fff;
+    box-shadow: -2px 0 5px rgba(0,0,0,0.2);
+    transform: translateX(100%);
+    transition: transform 0.3s ease;
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+}
+.notes-panel:not(.collapsed) {
+    transform: translateX(0);
+}
+.notes-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px;
+    background: #f4f4f4;
+}
+.notes-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    padding: 10px;
+    overflow-y: auto;
+}
+.notes-toolbar button {
+    margin-right: 5px;
+}
+.snapshot-container {
+    margin-top: 10px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+.snapshot-thumb {
+    width: 60px;
+    height: 60px;
+    object-fit: cover;
+    border: 1px solid #ccc;
+}
+
+.timeline-dock {
+    position: fixed;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    height: 160px;
+    background: #fff;
+    box-shadow: 0 -2px 5px rgba(0,0,0,0.2);
+    transform: translateY(100%);
+    transition: transform 0.3s ease;
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+}
+.timeline-dock:not(.collapsed) {
+    transform: translateY(0);
+}
+.timeline-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 5px 10px;
+    background: #f4f4f4;
+}
+.timeline-content {
+    flex: 1;
+    overflow-y: auto;
+    padding: 5px 10px;
+}
+.timeline-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+.timeline-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 4px;
+}
+.timeline-item img {
+    width: 24px;
+    height: 24px;
+    object-fit: cover;
+}
+
+.collapse-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+}
+
+.json-container {
+    position: relative;
+}
+.json-container pre {
+    background: #1e1e1e;
+    color: #dcdcdc;
+    padding: 10px;
+    border-radius: 4px;
+    overflow: auto;
+}
+.copy-btn {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    padding: 4px 8px;
+    font-size: 12px;
+    cursor: pointer;
+}
+
+body.dark-mode .json-container pre {
+    background: #000;
+    color: #eee;
+}

--- a/style.css
+++ b/style.css
@@ -476,6 +476,10 @@ main {
     min-height: 80px;
 }
 
+#details-notes {
+    min-height: 120px;
+}
+
 .modal-body input[type="text"]:focus {
     outline: none;
     border-color: #6e45e2;

--- a/tests/ligandDetails.test.js
+++ b/tests/ligandDetails.test.js
@@ -28,6 +28,7 @@ describe('LigandDetails viewer focus', () => {
     const resEl = makeEl();
     const viewerEl = makeEl();
     const jsonEl = makeEl();
+    const notesEl = makeEl();
 
     document.registerElement('molecule-details-modal', modalEl);
     document.registerElement('details-title', titleEl);
@@ -40,6 +41,7 @@ describe('LigandDetails viewer focus', () => {
     document.registerElement('details-residue', resEl);
     document.registerElement('details-viewer-container', viewerEl);
     document.registerElement('details-json', jsonEl);
+    document.registerElement('details-notes', notesEl);
 
     global.document = document;
     global.document.querySelectorAll = (sel) =>


### PR DESCRIPTION
## Summary
- add collapsible notes panel with markdown toolbar, tagging, snapshot capture, and timeline dock
- enable export of full notebook session and style JSON display with copy button
- hook notebook into molecule manager to log actions for molecules viewed or added

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898ee473ecc832995e7fd783d7246ab