### PR TITLE
Rename viewer interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
             <button class="tab-button active">Molecules</button>
             <button class="tab-button">Fragments</button>
             <button class="tab-button">Proteins</button>
-            <button class="tab-button">PyMOL</button>
+            <button class="tab-button">Viewer</button>
         </div>
         <div class="content">
             <div id="molecule-library-content" class="content-panel">
@@ -155,56 +155,56 @@
                         data...</div>
                 </div>
             </div>
-            <div id="pymol-interface-content" class="content-panel" style="display: none;">
+            <div id="viewer-interface-content" class="content-panel" style="display: none;">
                 <div class="database-header">
-                    <h2>PyMOL-style Viewer</h2>
+                    <h2>3D Viewer</h2>
                 </div>
                 <div class="protein-controls">
-                    <input type="text" id="pymol-pdb-id" placeholder="Enter PDB ID (e.g., 1CBS)">
-                    <button id="pymol-load-btn" class="action-btn">Load</button>
-                    <select id="pymol-color-scheme" title="Color scheme">
+                    <input type="text" id="viewer-pdb-id" placeholder="Enter PDB ID (e.g., 1CBS)">
+                    <button id="viewer-load-btn" class="action-btn">Load</button>
+                    <select id="viewer-color-scheme" title="Color scheme">
                         <option value="chain">Color: Chain</option>
                         <option value="spectrum">Color: Spectrum</option>
                         <option value="element">Color: Element</option>
                     </select>
                     <div class="toggle-switch">
-                        <input type="checkbox" id="pymol-hide-solvent" class="toggle-switch-checkbox" checked>
-                        <label class="toggle-switch-label" for="pymol-hide-solvent"></label>
+                        <input type="checkbox" id="viewer-hide-solvent" class="toggle-switch-checkbox" checked>
+                        <label class="toggle-switch-label" for="viewer-hide-solvent"></label>
                         <span>Hide Solvent</span>
                     </div>
                     <div class="toggle-switch">
-                        <input type="checkbox" id="pymol-hide-ions" class="toggle-switch-checkbox" checked>
-                        <label class="toggle-switch-label" for="pymol-hide-ions"></label>
+                        <input type="checkbox" id="viewer-hide-ions" class="toggle-switch-checkbox" checked>
+                        <label class="toggle-switch-label" for="viewer-hide-ions"></label>
                         <span>Hide Ions</span>
                     </div>
                     <div class="toggle-switch">
-                        <input type="checkbox" id="pymol-spin" class="toggle-switch-checkbox">
-                        <label class="toggle-switch-label" for="pymol-spin"></label>
+                        <input type="checkbox" id="viewer-spin" class="toggle-switch-checkbox">
+                        <label class="toggle-switch-label" for="viewer-spin"></label>
                         <span>Spin</span>
                     </div>
                 </div>
                 <div class="protein-controls">
                     <div class="toggle-switch">
-                        <input type="checkbox" id="pymol-cartoon" class="toggle-switch-checkbox" checked>
-                        <label class="toggle-switch-label" for="pymol-cartoon"></label>
+                        <input type="checkbox" id="viewer-cartoon" class="toggle-switch-checkbox" checked>
+                        <label class="toggle-switch-label" for="viewer-cartoon"></label>
                         <span>Cartoon</span>
                     </div>
                     <div class="toggle-switch">
-                        <input type="checkbox" id="pymol-sticks" class="toggle-switch-checkbox" checked>
-                        <label class="toggle-switch-label" for="pymol-sticks"></label>
+                        <input type="checkbox" id="viewer-sticks" class="toggle-switch-checkbox" checked>
+                        <label class="toggle-switch-label" for="viewer-sticks"></label>
                         <span>Ligand Sticks</span>
                     </div>
                     <div class="toggle-switch">
-                        <input type="checkbox" id="pymol-surface" class="toggle-switch-checkbox">
-                        <label class="toggle-switch-label" for="pymol-surface"></label>
+                        <input type="checkbox" id="viewer-surface" class="toggle-switch-checkbox">
+                        <label class="toggle-switch-label" for="viewer-surface"></label>
                         <span>Surface</span>
                     </div>
-                    <label for="pymol-surface-opacity">Surface opacity</label>
-                    <input id="pymol-surface-opacity" type="range" min="0" max="1" step="0.05" value="0.5">
-                    <button id="pymol-zoom-ligands" class="action-btn">Zoom Ligands</button>
-                    <button id="pymol-reset-view" class="action-btn">Reset View</button>
+                    <label for="viewer-surface-opacity">Surface opacity</label>
+                    <input id="viewer-surface-opacity" type="range" min="0" max="1" step="0.05" value="0.5">
+                    <button id="viewer-zoom-ligands" class="action-btn">Zoom Ligands</button>
+                    <button id="viewer-reset-view" class="action-btn">Reset View</button>
                 </div>
-                <div id="pymol-viewer" class="details-viewer">
+                <div id="viewer-container" class="details-viewer">
                     <p>Load a PDB to begin...</p>
                 </div>
             </div>

--- a/src/components/ViewerInterface.js
+++ b/src/components/ViewerInterface.js
@@ -1,6 +1,6 @@
 import ApiService from '../utils/apiService.js';
 
-class PyMolInterface {
+class ViewerInterface {
   constructor() {
     this.viewerContainer = null;
     this.viewer = null;
@@ -25,19 +25,19 @@ class PyMolInterface {
 
   init() {
     // Hook up DOM
-    this.viewerContainer = document.getElementById('pymol-viewer');
-    this.pdbInput = document.getElementById('pymol-pdb-id');
-    this.loadBtn = document.getElementById('pymol-load-btn');
-    this.showCartoon = document.getElementById('pymol-cartoon');
-    this.showSticks = document.getElementById('pymol-sticks');
-    this.showSurface = document.getElementById('pymol-surface');
-    this.surfaceOpacity = document.getElementById('pymol-surface-opacity');
-    this.colorScheme = document.getElementById('pymol-color-scheme');
-    this.hideSolvent = document.getElementById('pymol-hide-solvent');
-    this.hideIons = document.getElementById('pymol-hide-ions');
-    this.zoomLigandsBtn = document.getElementById('pymol-zoom-ligands');
-    this.resetViewBtn = document.getElementById('pymol-reset-view');
-    this.spinToggle = document.getElementById('pymol-spin');
+    this.viewerContainer = document.getElementById('viewer-container');
+    this.pdbInput = document.getElementById('viewer-pdb-id');
+    this.loadBtn = document.getElementById('viewer-load-btn');
+    this.showCartoon = document.getElementById('viewer-cartoon');
+    this.showSticks = document.getElementById('viewer-sticks');
+    this.showSurface = document.getElementById('viewer-surface');
+    this.surfaceOpacity = document.getElementById('viewer-surface-opacity');
+    this.colorScheme = document.getElementById('viewer-color-scheme');
+    this.hideSolvent = document.getElementById('viewer-hide-solvent');
+    this.hideIons = document.getElementById('viewer-hide-ions');
+    this.zoomLigandsBtn = document.getElementById('viewer-zoom-ligands');
+    this.resetViewBtn = document.getElementById('viewer-reset-view');
+    this.spinToggle = document.getElementById('viewer-spin');
 
     if (this.loadBtn) this.loadBtn.addEventListener('click', () => this.handleLoad());
     if (this.pdbInput) {
@@ -64,7 +64,7 @@ class PyMolInterface {
     this._resizeHandler = () => this.resizeToWindow();
     window.addEventListener('resize', this._resizeHandler);
     // Resize when panel becomes visible or layout changes
-    const panel = document.getElementById('pymol-interface-content');
+    const panel = document.getElementById('viewer-interface-content');
     if (panel && typeof ResizeObserver !== 'undefined') {
       const ro = new ResizeObserver(() => this.resizeToWindow());
       ro.observe(panel);
@@ -208,4 +208,4 @@ class PyMolInterface {
   }
 }
 
-export default PyMolInterface;
+export default ViewerInterface;

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@ import MoleculeCard from './components/MoleculeCard.js';
 import PdbDetailsModal from './modal/PdbDetailsModal.js';
 import AddMoleculeModal from './modal/AddMoleculeModal.js';
 import ProteinBrowser from './components/ProteinBrowser.js';
-import PyMolInterface from './components/PyMolInterface.js';
+import ViewerInterface from './components/ViewerInterface.js';
 import ComparisonModal from './modal/ComparisonModal.js';
 
 class MoleculeManager {
@@ -104,16 +104,16 @@ class MoleculeManager {
             document.getElementById('molecule-library-content'),
             document.getElementById('fragment-library-content'),
             document.getElementById('protein-browser-content'),
-            document.getElementById('pymol-interface-content')
+            document.getElementById('viewer-interface-content')
         ];
         tabButtons.forEach((button, index) => {
             button.addEventListener('click', () => {
                 tabButtons.forEach((btn, i) => btn.classList.toggle('active', i === index));
                 panels.forEach((panel, i) => {
                     panel.style.display = i === index ? 'block' : 'none';
-                    if (i === index && panel.id === 'pymol-interface-content' && window.pyMolInterface) {
+                    if (i === index && panel.id === 'viewer-interface-content' && window.viewerInterface) {
                         // Ensure the viewer resizes correctly when the tab is shown
-                        setTimeout(() => window.pyMolInterface.resizeToWindow(), 0);
+                        setTimeout(() => window.viewerInterface.resizeToWindow(), 0);
                     }
                 });
             });
@@ -288,7 +288,7 @@ if (confirmAddFragmentBtn) {
 }
 
 const proteinBrowser = new ProteinBrowser(moleculeManager).init();
-const pyMolInterface = new PyMolInterface().init();
+const viewerInterface = new ViewerInterface().init();
 
 function showNotification(message, type = 'info') {
     const notification = document.createElement('div');
@@ -333,7 +333,7 @@ function showNotification(message, type = 'info') {
 window.moleculeManager = moleculeManager;
 window.fragmentLibrary = fragmentLibrary;
 window.proteinBrowser = proteinBrowser;
-window.pyMolInterface = pyMolInterface;
+window.viewerInterface = viewerInterface;
 window.showNotification = showNotification;
 
 function toggleDarkMode() {

--- a/style.css
+++ b/style.css
@@ -670,14 +670,14 @@ main {
     color: #666;
 }
 
-/* PyMOL viewer fills remaining viewport height dynamically (JS adjusts height) */
-#pymol-viewer {
+/* Viewer fills remaining viewport height dynamically (JS adjusts height) */
+#viewer-container {
     height: auto;
     min-height: 300px;
 }
 
-/* Ensure PyMOL content layout stacks controls and viewer */
-#pymol-interface-content {
+/* Ensure viewer content layout stacks controls and viewer */
+#viewer-interface-content {
     display: flex;
     flex-direction: column;
     gap: 10px;


### PR DESCRIPTION
## Summary
- rename interface tab and controls to viewer terminology
- introduce ViewerInterface component and hook up new IDs
- align styles with viewer naming

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898ef81dc548329afdca642369442ee