### PR TITLE
Add pharmacophore view and PH4 export

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,6 +343,7 @@
                     <div id="details-viewer-container" class="details-viewer">
                         <p>Loading structure...</p>
                     </div>
+                    <button id="download-ph4-btn" style="display: none; margin-top: 10px;">Download PH4</button>
                 </div>
 
                 <div class="details-section">

--- a/tests/ligandDetails.test.js
+++ b/tests/ligandDetails.test.js
@@ -28,6 +28,7 @@ describe('LigandDetails viewer focus', () => {
     const resEl = makeEl();
     const viewerEl = makeEl();
     const jsonEl = makeEl();
+    const ph4Btn = makeEl();
 
     document.registerElement('molecule-details-modal', modalEl);
     document.registerElement('details-title', titleEl);
@@ -40,6 +41,7 @@ describe('LigandDetails viewer focus', () => {
     document.registerElement('details-residue', resEl);
     document.registerElement('details-viewer-container', viewerEl);
     document.registerElement('details-json', jsonEl);
+    document.registerElement('download-ph4-btn', ph4Btn);
 
     global.document = document;
     global.document.querySelectorAll = (sel) =>
@@ -63,6 +65,8 @@ describe('LigandDetails viewer focus', () => {
       addSurface: mock.fn(),
       zoomTo: mock.fn(),
       render: mock.fn(),
+      addSphere: mock.fn(),
+      getModel: () => ({ selectedAtoms: () => [] }),
       clear: () => {},
       destroy: () => {}
     };
@@ -80,6 +84,70 @@ describe('LigandDetails viewer focus', () => {
     assert.strictEqual(viewer.addSurface.mock.callCount(), 1);
     assert.strictEqual(viewer.addSurface.mock.calls[0].arguments[0], 'MS');
     assert.deepStrictEqual(viewer.setStyle.mock.calls[0].arguments, [{}, { cartoon: { color: 'lightgrey' } }]);
+    assert.strictEqual(viewer.addSphere.mock.callCount(), 0);
+    assert.strictEqual(ph4Btn.style.display, 'none');
+
+    mock.restoreAll();
+    delete global.$3Dmol;
+    delete global.document;
+    delete global.window;
+  });
+
+  it('detects pharmacophore features from SDF and enables download', async () => {
+    const dom = new JSDOM();
+    const { document } = dom.window;
+
+    const modalEl = makeEl();
+    const titleEl = makeEl();
+    const codeEl = makeEl();
+    const sourceEl = makeEl();
+    const typeEl = makeEl();
+    const structEl = makeEl();
+    const viewerEl = makeEl();
+    const jsonEl = makeEl();
+    const ph4Btn = makeEl();
+
+    document.registerElement('molecule-details-modal', modalEl);
+    document.registerElement('details-title', titleEl);
+    document.registerElement('details-code', codeEl);
+    document.registerElement('details-source', sourceEl);
+    document.registerElement('details-type', typeEl);
+    document.registerElement('details-structure', structEl);
+    document.registerElement('details-viewer-container', viewerEl);
+    document.registerElement('details-json', jsonEl);
+    document.registerElement('download-ph4-btn', ph4Btn);
+
+    global.document = document;
+    global.document.querySelectorAll = () => [];
+    global.window = { addEventListener: () => {} };
+
+    const model = {
+      atoms: [
+        { elem: 'N', bonds: [1], x: 1, y: 2, z: 3, aromatic: false },
+        { elem: 'H', bonds: [0], x: 0, y: 0, z: 0 }
+      ],
+      selectedAtoms: () => [{ elem: 'N', bonds: [1], x: 1, y: 2, z: 3, aromatic: false }]
+    };
+    const viewer = {
+      addModel: mock.fn(),
+      setStyle: mock.fn(),
+      render: mock.fn(),
+      addSphere: mock.fn(),
+      getModel: () => model,
+      clear: () => {},
+      destroy: () => {},
+      zoomTo: mock.fn()
+    };
+    global.$3Dmol = { createViewer: () => viewer };
+    mock.method(global, 'setTimeout', (fn) => { fn(); });
+
+    const ld = new LigandDetails({});
+    ld.show('AAA', 'SDFDATA');
+    await new Promise(setImmediate);
+
+    assert.strictEqual(viewer.addSphere.mock.callCount(), 1);
+    assert.strictEqual(ph4Btn.style.display, 'inline-block');
+    assert.strictEqual(ld.pharmacophoreFeatures.length, 1);
 
     mock.restoreAll();
     delete global.$3Dmol;


### PR DESCRIPTION
## Summary
- add Download PH4 button to ligand details modal
- auto-detect pharmacophore features and render spheres
- allow downloading detected features as a PH4 JSON file
- test pharmacophore feature detection and button visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898f08f59748329b1ea7c9d2a734785