### PR TITLE
feat: add dark theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
 
 <head>
     <meta charset="UTF-8">
@@ -36,6 +36,9 @@
 
     <!-- Main App Content -->
     <header>
+        <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">
+            <span id="theme-toggle-icon" class="material-icons">dark_mode</span>
+        </button>
         <h1>Ligand Surfer</h1>
         <p>Interactive exploration of ligands, fragments, and proteins</p>
         <p class="author">By Charlie Harris 🛡️</p>

--- a/src/components/MoleculeCard.js
+++ b/src/components/MoleculeCard.js
@@ -113,11 +113,13 @@ class MoleculeCard {
 
         setTimeout(() => {
             try {
-                const bgColor = document.body?.classList?.contains('dark-mode') ? '#e0e0e0' : 'white';
+                const dark = document?.documentElement?.getAttribute('data-theme') === 'dark';
+                const bgColor = dark ? '#0f1115' : 'white';
                 const viewer = $3Dmol.createViewer(viewerContainer, { backgroundColor: bgColor });
                 viewerContainer.viewer = viewer;
                 viewer.addModel(data, format);
-                viewer.setStyle({}, { stick: {} });
+                const stickOpts = { radius: dark ? 0.3 : 0.2, colorscheme: dark ? 'Jmol' : 'element' };
+                viewer.setStyle({}, { stick: stickOpts });
                 viewer.setStyle({ elem: 'H' }, {});
                 viewer.zoomTo();
                 viewer.render();

--- a/src/components/PyMolInterface.js
+++ b/src/components/PyMolInterface.js
@@ -79,7 +79,8 @@ class PyMolInterface {
 
   ensureViewer() {
     if (!this.viewer && this.viewerContainer) {
-      const bgColor = document.body?.classList?.contains('dark-mode') ? '#e0e0e0' : 'white';
+      const dark = document?.documentElement?.getAttribute('data-theme') === 'dark';
+      const bgColor = dark ? '#0f1115' : 'white';
       this.viewer = $3Dmol.createViewer(this.viewerContainer, {
         backgroundColor: bgColor,
         width: '100%',
@@ -135,6 +136,7 @@ class PyMolInterface {
     const hideIons = !!this.hideIons?.checked;
     const scheme = this.colorScheme?.value || 'chain';
     const opacity = Number(this.surfaceOpacity?.value || 0.5);
+    const dark = document?.documentElement?.getAttribute('data-theme') === 'dark';
 
     // Clear styles and surfaces
     this.viewer.setStyle({}, {});
@@ -156,8 +158,9 @@ class PyMolInterface {
 
     // Sticks for hetero
     if (showSticks) {
-      // Always color ligands (hetero) by element; slightly thicker sticks
-      this.viewer.setStyle(hetSelection, { stick: { radius: 0.25, colorscheme: 'element' } });
+      const stickRadius = dark ? 0.3 : 0.25;
+      const stickScheme = dark ? 'Jmol' : 'element';
+      this.viewer.setStyle(hetSelection, { stick: { radius: stickRadius, colorscheme: stickScheme } });
     }
 
     // Surface for polymer

--- a/src/main.js
+++ b/src/main.js
@@ -336,29 +336,53 @@ window.proteinBrowser = proteinBrowser;
 window.pyMolInterface = pyMolInterface;
 window.showNotification = showNotification;
 
-function toggleDarkMode() {
-    document.body.classList.toggle('dark-mode');
-    const isDark = document.body.classList.contains('dark-mode');
-    const bg = isDark ? '#e0e0e0' : 'white';
+function applyTheme(theme) {
+    const root = document.documentElement;
+    root.setAttribute('data-theme', theme);
+    try {
+        localStorage.setItem('theme', theme);
+    } catch (_) { }
+    const dark = theme === 'dark';
+    const bg = dark ? '#0f1115' : 'white';
     document.querySelectorAll('.viewer-container, .molecule-viewer, .details-viewer').forEach(el => {
         if (el.viewer && typeof el.viewer.setBackgroundColor === 'function') {
             el.viewer.setBackgroundColor(bg);
+            if (typeof el.viewer.setStyle === 'function') {
+                el.viewer.setStyle({}, { stick: { radius: dark ? 0.3 : 0.2, colorscheme: dark ? 'Jmol' : 'element' } });
+                el.viewer.setStyle({ elem: 'H' }, {});
+            }
             el.viewer.render();
         } else {
             el.style.background = bg;
         }
     });
     const icon = document.getElementById('theme-toggle-icon');
-    if (icon) {
-        icon.textContent = isDark ? 'light_mode' : 'dark_mode';
+    if (icon) icon.textContent = dark ? 'light_mode' : 'dark_mode';
+}
+
+function initTheme() {
+    let stored;
+    try {
+        stored = localStorage.getItem('theme');
+    } catch (_) {
+        stored = null;
     }
+    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const theme = stored || (prefersDark ? 'dark' : 'light');
+    applyTheme(theme);
+}
+
+function toggleTheme() {
+    const current = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    applyTheme(current);
 }
 
 function initThemeToggle() {
     const btn = document.getElementById('theme-toggle');
     if (btn) {
-        btn.addEventListener('click', toggleDarkMode);
+        btn.addEventListener('click', toggleTheme);
     }
 }
 
+initTheme();
 initThemeToggle();

--- a/src/modal/ComparisonModal.js
+++ b/src/modal/ComparisonModal.js
@@ -27,13 +27,14 @@ class ComparisonModal {
         }
         setTimeout(() => {
             try {
-                const bgColor = document.body?.classList?.contains('dark-mode') ? '#e0e0e0' : 'white';
+                const dark = document?.documentElement?.getAttribute('data-theme') === 'dark';
+                const bgColor = dark ? '#0f1115' : 'white';
                 const viewer = $3Dmol.createViewer(this.viewerContainer, { backgroundColor: bgColor });
                 this.viewerContainer.viewer = viewer;
                 const model1 = viewer.addModel(molA.sdf, 'sdf');
                 const model2 = viewer.addModel(molB.sdf, 'sdf');
-                model1.setStyle({}, { stick: { colorscheme: 'cyanCarbon' } });
-                model2.setStyle({}, { stick: { colorscheme: 'magentaCarbon' } });
+                model1.setStyle({}, { stick: { colorscheme: 'cyanCarbon', radius: dark ? 0.3 : 0.2 } });
+                model2.setStyle({}, { stick: { colorscheme: 'magentaCarbon', radius: dark ? 0.3 : 0.2 } });
                 this._alignModels(model1, model2);
                 viewer.zoomTo();
                 viewer.render();

--- a/src/modal/LigandDetails.js
+++ b/src/modal/LigandDetails.js
@@ -63,7 +63,8 @@ class LigandDetails {
                 .then(pdbData => {
                     setTimeout(() => {
                         try {
-                            const bgColor = document.body?.classList?.contains('dark-mode') ? '#e0e0e0' : 'white';
+                            const dark = document?.documentElement?.getAttribute('data-theme') === 'dark';
+                            const bgColor = dark ? '#0f1115' : 'white';
                             const viewer = $3Dmol.createViewer(this.detailsViewer, {
                                 backgroundColor: bgColor,
                                 width: '100%',
@@ -80,12 +81,12 @@ class LigandDetails {
                             const pocketSel = { within: { distance: 5, sel: ligandSel } };
                             // Surrounding residues as element-coloured sticks
                             viewer.setStyle(pocketSel, {
-                                stick: { radius: 0.15, colorscheme: 'element' }
+                                stick: { radius: dark ? 0.25 : 0.15, colorscheme: dark ? 'Jmol' : 'element' }
                             });
                             // Ligand in ball-and-stick with element colouring
                             viewer.setStyle(ligandSel, {
-                                stick: { radius: 0.2, colorscheme: 'element' },
-                                sphere: { scale: 0.3, colorscheme: 'element' }
+                                stick: { radius: dark ? 0.3 : 0.2, colorscheme: dark ? 'Jmol' : 'element' },
+                                sphere: { scale: 0.3, colorscheme: dark ? 'Jmol' : 'element' }
                             });
                             // Transparent surface around binding pocket
                             viewer.addSurface($3Dmol.SurfaceType.MS,
@@ -108,7 +109,8 @@ class LigandDetails {
         } else if (sdfData) {
             setTimeout(() => {
                 try {
-                    const bgColor = document.body?.classList?.contains('dark-mode') ? '#e0e0e0' : 'white';
+                    const dark = document?.documentElement?.getAttribute('data-theme') === 'dark';
+                    const bgColor = dark ? '#0f1115' : 'white';
                     const viewer = $3Dmol.createViewer(this.detailsViewer, {
                         backgroundColor: bgColor,
                         width: '100%',
@@ -116,10 +118,9 @@ class LigandDetails {
                     });
                     this.detailsViewer.viewer = viewer;
                     viewer.addModel(sdfData, 'sdf');
-                    viewer.setStyle({}, {
-                        stick: { radius: 0.2, colorscheme: 'element' },
-                        sphere: { scale: 0.3, colorscheme: 'element' }
-                    });
+                    const stick = { radius: dark ? 0.3 : 0.2, colorscheme: dark ? 'Jmol' : 'element' };
+                    const sphere = { scale: 0.3, colorscheme: dark ? 'Jmol' : 'element' };
+                    viewer.setStyle({}, { stick, sphere });
                     viewer.setStyle({ elem: 'H' }, {});
                     viewer.zoomTo();
                     viewer.render();

--- a/src/modal/PdbDetailsModal.js
+++ b/src/modal/PdbDetailsModal.js
@@ -61,7 +61,8 @@ class PdbDetailsModal {
 
             setTimeout(() => {
                 try {
-                    const bgColor = document.body?.classList?.contains('dark-mode') ? '#e0e0e0' : 'white';
+                    const dark = document?.documentElement?.getAttribute('data-theme') === 'dark';
+                    const bgColor = dark ? '#0f1115' : 'white';
                     const viewer = $3Dmol.createViewer(viewerContainer, {
                         backgroundColor: bgColor,
                         width: '100%',
@@ -72,7 +73,7 @@ class PdbDetailsModal {
                     viewer.setStyle({}, { cartoon: { color: '#b3b3b3', opacity: 0.7 } });
                     // highlight bound ligands with element-based colors using thick sticks
                     viewer.setStyle({ hetflag: true }, {
-                        stick: { radius: 0.5, colorscheme: 'element' }
+                        stick: { radius: dark ? 0.6 : 0.5, colorscheme: dark ? 'Jmol' : 'element' }
                     });
                     viewer.setStyle({ hetflag: true, resn: ['HOH', 'H2O', 'WAT'] }, {});
                     viewer.zoomTo();

--- a/style.css
+++ b/style.css
@@ -1,12 +1,33 @@
+/* Theme variables */
+:root {
+    --bg: #f4f6f8;
+    --bg-elev: #ffffff;
+    --text: #333333;
+    --muted: #555555;
+    --primary: #6e45e2;
+    --accent: #88d3ce;
+    --ring: #00e8c6;
+}
+
+[data-theme="dark"] {
+    --bg: #0f1115;
+    --bg-elev: #1a1d23;
+    --text: #e4e4e4;
+    --muted: #a0a0a0;
+    --primary: #8e75ff;
+    --accent: #00e8c6;
+    --ring: #00e8c6;
+}
+
 body {
     font-family: 'Roboto', sans-serif;
     margin: 0;
-    background-color: #f4f6f8;
-    color: #333;
+    background-color: var(--bg);
+    color: var(--text);
 }
 
 header {
-    background: linear-gradient(90deg, #6e45e2 0%, #88d3ce 100%);
+    background: linear-gradient(90deg, var(--primary) 0%, var(--accent) 100%);
     color: white;
     padding: 20px 40px;
     text-align: center;
@@ -40,8 +61,12 @@ main {
 
 .tabs {
     display: flex;
-    border-bottom: 1px solid #ddd;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
     margin-bottom: 20px;
+}
+
+[data-theme="dark"] .tabs {
+    border-bottom-color: rgba(255, 255, 255, 0.1);
 }
 
 .tab-button {
@@ -51,13 +76,13 @@ main {
     cursor: pointer;
     font-size: 16px;
     font-weight: 500;
-    color: #555;
+    color: var(--muted);
     position: relative;
     transition: color 0.3s;
 }
 
 .tab-button.active {
-    color: #6e45e2;
+    color: var(--primary);
 }
 
 .tab-button.active::after {
@@ -67,7 +92,7 @@ main {
     left: 0;
     width: 100%;
     height: 3px;
-    background-color: #6e45e2;
+    background-color: var(--primary);
 }
 
 .content {
@@ -84,16 +109,23 @@ main {
     align-items: center;
     margin-bottom: 20px;
     padding: 10px;
-    background-color: #f9f9f9;
+    background-color: var(--bg-elev);
     border-radius: 8px;
 }
 
 .fragment-controls input[type="text"],
 .fragment-controls select {
     padding: 8px 12px;
-    border: 1px solid #ddd;
+    border: 1px solid rgba(0, 0, 0, 0.1);
     border-radius: 4px;
     font-size: 14px;
+    background: var(--bg);
+    color: var(--text);
+}
+
+[data-theme="dark"] .fragment-controls input[type="text"],
+[data-theme="dark"] .fragment-controls select {
+    border-color: rgba(255, 255, 255, 0.1);
 }
 
 .protein-controls {
@@ -102,20 +134,70 @@ main {
     align-items: center;
     margin-bottom: 20px;
     padding: 10px;
-    background-color: #f9f9f9;
+    background-color: var(--bg-elev);
     border-radius: 8px;
 }
 
 .protein-controls input[type="text"],
 .protein-controls select {
     padding: 8px 12px;
-    border: 1px solid #ddd;
+    border: 1px solid rgba(0, 0, 0, 0.1);
     border-radius: 4px;
     font-size: 14px;
+    background: var(--bg);
+    color: var(--text);
+}
+
+[data-theme="dark"] .protein-controls input[type="text"],
+[data-theme="dark"] .protein-controls select {
+    border-color: rgba(255, 255, 255, 0.1);
 }
 
 .protein-controls select {
     min-width: 200px;
+}
+
+/* Generic focus ring */
+button:focus,
+input:focus,
+select:focus,
+textarea:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--ring);
+}
+
+/* Tables */
+table {
+    width: 100%;
+    border-collapse: collapse;
+    background-color: var(--bg-elev);
+    color: var(--text);
+}
+
+th, td {
+    padding: 8px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+[data-theme="dark"] th,
+[data-theme="dark"] td {
+    border-bottom-color: rgba(255, 255, 255, 0.1);
+}
+
+/* Modals */
+.modal-content {
+    background-color: var(--bg-elev);
+    color: var(--text);
+}
+
+.modal-header,
+.modal-footer {
+    border-color: rgba(0, 0, 0, 0.1);
+}
+
+[data-theme="dark"] .modal-header,
+[data-theme="dark"] .modal-footer {
+    border-color: rgba(255, 255, 255, 0.1);
 }
 
 .fragment-card {
@@ -1167,8 +1249,8 @@ main {
 }
 
 .molecule-card {
-    background: white;
-    border: 1px solid #e0e0e0;
+    background: var(--bg-elev);
+    border: 1px solid rgba(0, 0, 0, 0.1);
     border-radius: 8px;
     padding: 10px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
@@ -1177,6 +1259,11 @@ main {
     flex-direction: column;
     justify-content: space-between;
     position: relative;
+}
+
+[data-theme="dark"] .molecule-card {
+    border-color: rgba(255, 255, 255, 0.1);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
 }
 
 .drag-handle {
@@ -1334,22 +1421,26 @@ main {
     margin: 0 0 5px;
     font-size: 14px;
     font-weight: 500;
-    color: #6e45e2;
+    color: var(--primary);
 }
 
 .molecule-card .formula {
     margin: 0 0 10px;
     font-size: 12px;
-    color: #888;
+    color: var(--muted);
 }
 
 .molecule-card .viewer-container {
     width: 100%;
     height: 200px;
-    /* Adjust as needed */
     position: relative;
-    border: 1px solid #eee;
+    border: 1px solid rgba(0, 0, 0, 0.1);
     border-radius: 4px;
+    background: var(--bg-elev);
+}
+
+[data-theme="dark"] .molecule-card .viewer-container {
+    border-color: rgba(255, 255, 255, 0.1);
 }
 
 .fragment-card .viewer-container {
@@ -1373,7 +1464,7 @@ main {
 .molecule-card .info {
     margin-top: 10px;
     font-size: 12px;
-    color: #666;
+    color: var(--muted);
     display: flex;
     justify-content: space-between;
 }
@@ -1381,7 +1472,7 @@ main {
 .molecule-card p {
     margin: 10px 0 0;
     font-size: 14px;
-    color: #666;
+    color: var(--muted);
 }
 
 .loading-indicator {
@@ -1730,71 +1821,10 @@ main {
     left: 20px;
     background: transparent;
     border: none;
-    color: white;
+    color: inherit;
     cursor: pointer;
 }
 
 .theme-toggle .material-icons {
     font-size: 24px;
-}
-
-/* Dark mode styles */
-body.dark-mode {
-    background-color: #121212;
-    color: #eee;
-}
-
-body.dark-mode header {
-    background: linear-gradient(90deg, #333 0%, #555 100%);
-}
-
-body.dark-mode .theme-toggle {
-    color: #ffd54f;
-}
-
-body.dark-mode .tabs {
-    border-bottom-color: #444;
-}
-
-body.dark-mode .tab-button {
-    color: #bbb;
-}
-
-body.dark-mode .tab-button.active {
-    color: #fff;
-}
-
-body.dark-mode .tab-button.active::after {
-    background-color: #fff;
-}
-
-body.dark-mode .fragment-controls,
-body.dark-mode .protein-controls {
-    background-color: #2c2c2c;
-}
-
-body.dark-mode .database-header h2 {
-    color: #eee;
-}
-
-body.dark-mode .molecule-card {
-    background: #151515;
-    border-color: #333;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
-}
-
-body.dark-mode .molecule-card h3 {
-    color: #88d3ce;
-}
-
-body.dark-mode .molecule-card .formula,
-body.dark-mode .molecule-card .info,
-body.dark-mode .molecule-card p {
-    color: #ccc;
-}
-
-body.dark-mode .viewer-container,
-body.dark-mode .molecule-viewer,
-body.dark-mode .details-viewer {
-    background: #e0e0e0;
 }


### PR DESCRIPTION
## Summary
- introduce CSS variables and dark theme styling
- add theme toggle with persistence and system preference
- brighten 3D viewer atoms and increase stick thickness for dark mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898ee33dfd88329ad24c9d8d185aada