### PR TITLE
Add DFT data viewer interface

### DIFF
--- a/src/components/DftDataViewer.js
+++ b/src/components/DftDataViewer.js
@@ -1,0 +1,47 @@
+import ApiService from '../utils/apiService.js';
+
+/**
+ * Simple interface for displaying Density Functional Theory (DFT) data
+ * for a particular chemical component. The viewer expects a section with
+ * id `dft-data-section` that contains a table body `dft-data-tbody` where
+ * each property/value pair will be rendered as rows.
+ */
+class DftDataViewer {
+  /**
+   * Fetch and render DFT data for the given CCD code.
+   *
+   * @param {string} ccdCode - Three letter chemical component code.
+   * @returns {Promise<void>}
+   */
+  async show(ccdCode) {
+    const section = document.getElementById('dft-data-section');
+    const tbody = document.getElementById('dft-data-tbody');
+    if (!section || !tbody) return;
+
+    tbody.innerHTML = '';
+    try {
+      const data = await ApiService.getDftData(ccdCode);
+      if (!data || Object.keys(data).length === 0) {
+        section.style.display = 'none';
+        return;
+      }
+
+      section.style.display = 'block';
+      Object.entries(data).forEach(([key, value]) => {
+        const row = document.createElement('tr');
+        const keyCell = document.createElement('td');
+        keyCell.textContent = key;
+        const valueCell = document.createElement('td');
+        valueCell.textContent = String(value);
+        row.appendChild(keyCell);
+        row.appendChild(valueCell);
+        tbody.appendChild(row);
+      });
+    } catch (err) {
+      console.error('Error fetching DFT data:', err);
+      section.style.display = 'none';
+    }
+  }
+}
+
+export default DftDataViewer;

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@ import AddMoleculeModal from './modal/AddMoleculeModal.js';
 import ProteinBrowser from './components/ProteinBrowser.js';
 import ViewerInterface from './components/ViewerInterface.js';
 import ComparisonModal from './modal/ComparisonModal.js';
+import DftDataViewer from './components/DftDataViewer.js';
 
 class MoleculeManager {
     constructor() {
@@ -289,6 +290,7 @@ if (confirmAddFragmentBtn) {
 
 const proteinBrowser = new ProteinBrowser(moleculeManager).init();
 const viewerInterface = new ViewerInterface().init();
+const dftDataViewer = new DftDataViewer();
 
 function showNotification(message, type = 'info') {
     const notification = document.createElement('div');
@@ -334,6 +336,7 @@ window.moleculeManager = moleculeManager;
 window.fragmentLibrary = fragmentLibrary;
 window.proteinBrowser = proteinBrowser;
 window.viewerInterface = viewerInterface;
+window.dftDataViewer = dftDataViewer;
 window.showNotification = showNotification;
 
 function toggleDarkMode() {

--- a/src/utils/apiService.js
+++ b/src/utils/apiService.js
@@ -298,9 +298,25 @@ export default class ApiService {
    * - Used for analyzing protein-ligand interactions
    *
    * @see https://www.ebi.ac.uk/pdbe/graph-api/pdbe_doc/ for bound ligands API
-   */
+  */
   static getLigandMonomers(pdbId) {
     return this.fetchJson(`${PD_BE_LIGAND_MONOMERS_BASE_URL}/${pdbId}`);
+  }
+
+  /**
+   * Fetch Density Functional Theory (DFT) data for a chemical component.
+   *
+   * The application stores pre-computed DFT properties in JSON files grouped
+   * by chemical component code. This helper loads the JSON for a given CCD
+   * code and returns the parsed object. The exact shape of the data depends on
+   * the calculation but typically contains key/value pairs such as energies or
+   * orbital information.
+   *
+   * @param {string} ccdCode - Three letter chemical component code.
+   * @returns {Promise<Object>} Parsed DFT data object.
+   */
+  static getDftData(ccdCode) {
+    return this.fetchJson(`/data/dft/${ccdCode.toUpperCase()}.json`);
   }
 
   /**

--- a/tests/dftDataViewer.test.js
+++ b/tests/dftDataViewer.test.js
@@ -1,0 +1,56 @@
+import { describe, it, beforeEach, afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM, Element } from './domStub.js';
+import DftDataViewer from '../src/components/DftDataViewer.js';
+import ApiService from '../src/utils/apiService.js';
+
+let dom;
+
+const setupDom = () => {
+  dom = new JSDOM();
+  const { document } = dom.window;
+  document.createElement = (tag) => {
+    const el = new Element(tag);
+    el.style = {};
+    return el;
+  };
+  global.window = dom.window;
+  global.document = document;
+  const section = document.createElement('div');
+  const tbody = document.createElement('tbody');
+  document.registerElement('dft-data-section', section);
+  document.registerElement('dft-data-tbody', tbody);
+};
+
+describe('DftDataViewer', () => {
+  beforeEach(() => {
+    setupDom();
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
+    delete global.document;
+    delete global.window;
+  });
+
+  it('renders rows for DFT properties', async () => {
+    const data = { energy: -10.5, gap: 2.1 };
+    mock.method(ApiService, 'getDftData', async () => data);
+    const viewer = new DftDataViewer();
+    await viewer.show('AAA');
+    const section = document.getElementById('dft-data-section');
+    const tbody = document.getElementById('dft-data-tbody');
+    assert.strictEqual(section.style.display, 'block');
+    assert.strictEqual(tbody.children.length, 2);
+    assert.strictEqual(tbody.children[0].children[0].textContent, 'energy');
+    assert.strictEqual(tbody.children[0].children[1].textContent, '-10.5');
+  });
+
+  it('hides section when fetch fails', async () => {
+    mock.method(ApiService, 'getDftData', async () => { throw new Error('oops'); });
+    const viewer = new DftDataViewer();
+    await viewer.show('AAA');
+    const section = document.getElementById('dft-data-section');
+    assert.strictEqual(section.style.display, 'none');
+  });
+});


### PR DESCRIPTION
## Summary
- add `DftDataViewer` component to render Density Functional Theory (DFT) properties
- expose viewer in main app and add ApiService helper to load DFT JSON
- cover DFT interface with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a029a404483298c950a17e7a2a776