### PR TITLE
Add interacting sidechain visualization button

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,6 +203,7 @@
                     <input id="viewer-surface-opacity" type="range" min="0" max="1" step="0.05" value="0.5">
                     <button id="viewer-zoom-ligands" class="action-btn">Zoom Ligands</button>
                     <button id="viewer-reset-view" class="action-btn">Reset View</button>
+                    <button id="viewer-show-interactions" class="action-btn">Show Interactions</button>
                 </div>
                 <div id="viewer-container" class="details-viewer">
                     <p>Load a PDB to begin...</p>

--- a/src/components/ViewerInterface.js
+++ b/src/components/ViewerInterface.js
@@ -19,6 +19,7 @@ class ViewerInterface {
     this.zoomLigandsBtn = null;
     this.resetViewBtn = null;
     this.spinToggle = null;
+    this.showInteractionsBtn = null;
 
     this._resizeHandler = null;
   }
@@ -38,6 +39,7 @@ class ViewerInterface {
     this.zoomLigandsBtn = document.getElementById('viewer-zoom-ligands');
     this.resetViewBtn = document.getElementById('viewer-reset-view');
     this.spinToggle = document.getElementById('viewer-spin');
+    this.showInteractionsBtn = document.getElementById('viewer-show-interactions');
 
     if (this.loadBtn) this.loadBtn.addEventListener('click', () => this.handleLoad());
     if (this.pdbInput) {
@@ -59,6 +61,7 @@ class ViewerInterface {
     if (this.zoomLigandsBtn) this.zoomLigandsBtn.addEventListener('click', () => this.zoomLigands());
     if (this.resetViewBtn) this.resetViewBtn.addEventListener('click', () => this.resetView());
     if (this.spinToggle) this.spinToggle.addEventListener('change', () => this.updateSpin());
+    if (this.showInteractionsBtn) this.showInteractionsBtn.addEventListener('click', () => this.showInteractingSidechains());
 
     // Dynamic sizing
     this._resizeHandler = () => this.resizeToWindow();
@@ -177,6 +180,29 @@ class ViewerInterface {
   resetView() {
     if (!this.viewer) return;
     this.viewer.zoomTo();
+    this.viewer.render();
+  }
+
+  showInteractingSidechains() {
+    if (!this.viewer) return;
+    // Reapply base styles to ensure consistent state
+    this.applyStyles();
+
+    const notList = [];
+    if (this.hideSolvent?.checked) notList.push(...this.getSolventResidues());
+    if (this.hideIons?.checked) notList.push(...this.getIonResidues());
+
+    const ligandSel = notList.length
+      ? { hetflag: true, not: { resn: notList } }
+      : { hetflag: true };
+
+    const interactingSel = {
+      byres: true,
+      within: { distance: 5, sel: ligandSel },
+      not: { atom: ['N', 'CA', 'C', 'O', 'OXT'] }
+    };
+
+    this.viewer.setStyle(interactingSel, { stick: { colorscheme: 'element' } });
     this.viewer.render();
   }
 

--- a/tests/viewerInterface.test.js
+++ b/tests/viewerInterface.test.js
@@ -1,0 +1,66 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import ViewerInterface from '../src/components/ViewerInterface.js';
+import { JSDOM } from './domStub.js';
+
+const makeEl = () => ({
+  style: {},
+  addEventListener: () => {},
+  innerHTML: '',
+  textContent: '',
+  value: '',
+  checked: false,
+  getBoundingClientRect: () => ({ top: 0 })
+});
+
+describe('ViewerInterface interactions', () => {
+  it('shows sidechain sticks for interacting residues', () => {
+    const dom = new JSDOM();
+    const { document } = dom.window;
+
+    const viewerContainer = makeEl();
+    document.registerElement('viewer-container', viewerContainer);
+    document.registerElement('viewer-pdb-id', makeEl());
+    document.registerElement('viewer-load-btn', makeEl());
+    document.registerElement('viewer-cartoon', { ...makeEl(), checked: false });
+    document.registerElement('viewer-sticks', { ...makeEl(), checked: false });
+    document.registerElement('viewer-surface', makeEl());
+    document.registerElement('viewer-surface-opacity', { ...makeEl(), value: 0.5 });
+    document.registerElement('viewer-color-scheme', { ...makeEl(), value: 'chain' });
+    document.registerElement('viewer-hide-solvent', { ...makeEl(), checked: false });
+    document.registerElement('viewer-hide-ions', { ...makeEl(), checked: false });
+    document.registerElement('viewer-zoom-ligands', makeEl());
+    document.registerElement('viewer-reset-view', makeEl());
+    document.registerElement('viewer-spin', makeEl());
+    document.registerElement('viewer-show-interactions', makeEl());
+    document.registerElement('viewer-interface-content', makeEl());
+
+    global.document = document;
+    global.window = { addEventListener: () => {}, removeEventListener: () => {} };
+
+    const vi = new ViewerInterface().init();
+
+    const viewer = {
+      setStyle: mock.fn(),
+      removeAllSurfaces: mock.fn(),
+      render: mock.fn(),
+      resize: mock.fn()
+    };
+
+    vi.viewer = viewer;
+
+    vi.showInteractingSidechains();
+
+    assert.strictEqual(viewer.setStyle.mock.callCount(), 2);
+    const [sel, style] = viewer.setStyle.mock.calls[1].arguments;
+    assert.deepStrictEqual(sel.within, { distance: 5, sel: { hetflag: true } });
+    assert.strictEqual(sel.byres, true);
+    assert.deepStrictEqual(sel.not, { atom: ['N', 'CA', 'C', 'O', 'OXT'] });
+    assert.deepStrictEqual(style, { stick: { colorscheme: 'element' } });
+
+    mock.restoreAll();
+    delete global.document;
+    delete global.window;
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `Show Interactions` button to viewer controls
- render side-chain sticks for residues near ligands
- cover interaction rendering with unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a570721cc83299aa405a52cf81bfd