### PR TITLE
Add enzyme data page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ligand Surfer
 
-Ligand Surfer is a demo application for exploring molecular structures, fragments and proteins. It combines local fragment libraries with live data from the PDBe and RCSB APIs to provide quick visualisations and analysis.
+Ligand Surfer is a demo application for exploring molecular structures, fragments, proteins and enzymes. It combines local fragment libraries with live data from the PDBe and RCSB APIs to provide quick visualisations and analysis.
 
 ## Requirements
 - Node.js 18 or later

--- a/data/enzymes.json
+++ b/data/enzymes.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "Alkaline phosphatase",
+    "ecNumber": "3.1.3.1",
+    "description": "Hydrolyzes phosphate groups from molecules."
+  },
+  {
+    "name": "DNA polymerase I",
+    "ecNumber": "2.7.7.7",
+    "description": "Synthesizes DNA molecules from deoxyribonucleotides."
+  },
+  {
+    "name": "Lysozyme",
+    "ecNumber": "3.2.1.17",
+    "description": "Breaks down bacterial cell walls."
+  }
+]

--- a/enzymes.html
+++ b/enzymes.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Enzyme Explorer</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>Enzyme Explorer</h1>
+    <p>Browse enzyme information</p>
+    <nav><a href="index.html">Back to main app</a></nav>
+  </header>
+  <main>
+    <table id="enzyme-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>EC Number</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </main>
+  <script type="module" src="./src/enzymes.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
         <h1>Ligand Surfer</h1>
         <p>Interactive exploration of ligands, fragments, and proteins</p>
         <p class="author">By Charlie Harris 🛡️</p>
+        <nav><a href="enzymes.html">Enzymes</a></nav>
     </header>
     <main>
         <div class="tabs">

--- a/src/enzymes.js
+++ b/src/enzymes.js
@@ -1,0 +1,20 @@
+async function loadEnzymes() {
+  try {
+    const response = await fetch('./data/enzymes.json');
+    const enzymes = await response.json();
+    const tbody = document.querySelector('#enzyme-table tbody');
+    enzymes.forEach(enzyme => {
+      const row = document.createElement('tr');
+      row.innerHTML = `
+        <td>${enzyme.name}</td>
+        <td>${enzyme.ecNumber}</td>
+        <td>${enzyme.description}</td>
+      `;
+      tbody.appendChild(row);
+    });
+  } catch (err) {
+    console.error('Failed to load enzymes', err);
+  }
+}
+
+loadEnzymes();


### PR DESCRIPTION
## Summary
- add standalone Enzyme Explorer page and script to render enzyme info
- link new page from main index
- document enzyme data availability in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1dbb3dc6883298fd8cde45c3e5d02