### PR TITLE
Refresh UI with Claude-inspired styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Ligand Surfer</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <script src="https://unpkg.com/@rdkit/rdkit/Code/MinimalLib/dist/RDKit_minimal.js"></script>
@@ -35,12 +38,17 @@
     </div>
 
     <!-- Main App Content -->
-    <header>
-        <h1>Ligand Surfer</h1>
-        <p>Interactive exploration of ligands, fragments, and proteins</p>
-        <p class="author">By Charlie Harris 🛡️</p>
-    </header>
-    <main>
+    <div class="app-shell">
+        <header>
+            <button id="theme-toggle" class="theme-toggle">
+                <span class="material-icons" id="theme-toggle-icon">dark_mode</span>
+                <span>Toggle theme</span>
+            </button>
+            <h1>Ligand Surfer</h1>
+            <p>Interactive exploration of ligands, fragments, and proteins</p>
+            <p class="author">By Charlie Harris 🛡️</p>
+        </header>
+        <main>
         <div class="tabs">
             <button class="tab-button active">Molecules</button>
             <button class="tab-button">Fragments</button>
@@ -209,7 +217,8 @@
                 </div>
             </div>
         </div>
-    </main>
+        </main>
+    </div>
 
     <!-- Add Fragment Modal -->
     <div id="add-fragment-modal" class="modal">

--- a/src/components/MoleculeCard.js
+++ b/src/components/MoleculeCard.js
@@ -72,7 +72,7 @@ class MoleculeCard {
         smilesLabel.className = 'smiles-label';
         smilesLabel.textContent = `SMILES: ${smiles}`;
         smilesLabel.style.fontSize = '10px';
-        smilesLabel.style.color = '#666';
+        smilesLabel.style.color = 'var(--text-muted)';
         smilesLabel.style.marginTop = '5px';
         card.appendChild(smilesLabel);
 
@@ -83,10 +83,10 @@ class MoleculeCard {
 
     renderSmilesIn2D(smiles, container) {
         container.innerHTML = `
-            <div style="display:flex;align-items:center;justify-content:center;height:100%;background:#f8f9fa;border:1px solid #e9ecef;border-radius:4px;">
+            <div style="display:flex;align-items:center;justify-content:center;height:100%;background:var(--surface-color);border:1px solid var(--surface-border);border-radius:18px;box-shadow:inset 0 1px 0 var(--surface-highlight);">
                 <div style="text-align:center;padding:10px;">
                     <div style="font-size:24px;margin-bottom:5px;">🧪</div>
-                    <div style="font-size:10px;color:#666;">SMILES</div>
+                    <div style="font-size:10px;color:var(--text-muted);">SMILES</div>
                 </div>
             </div>
         `;

--- a/style.css
+++ b/style.css
@@ -1,121 +1,256 @@
-body {
-    font-family: 'Roboto', sans-serif;
-    margin: 0;
-    background-color: #f4f6f8;
-    color: #333;
+:root {
+    --bg-color: #070b1e;
+    --bg-gradient: radial-gradient(circle at 20% -10%, rgba(148, 163, 255, 0.25), transparent 55%),
+        radial-gradient(circle at 85% 0%, rgba(15, 118, 255, 0.18), transparent 50%),
+        #070b1e;
+    --shell-surface: rgba(11, 18, 37, 0.72);
+    --shell-border: rgba(148, 163, 184, 0.25);
+    --surface-color: rgba(15, 23, 42, 0.68);
+    --surface-border: rgba(148, 163, 184, 0.22);
+    --surface-highlight: rgba(248, 250, 255, 0.06);
+    --accent-color: #c7b6ff;
+    --accent-strong: #a893ff;
+    --accent-muted: rgba(199, 182, 255, 0.16);
+    --text-primary: #e7ecff;
+    --text-secondary: #b8c2e6;
+    --text-muted: rgba(184, 194, 230, 0.7);
+    --tab-rail: rgba(148, 163, 184, 0.08);
+    --tab-shadow: 0 12px 30px rgba(79, 70, 229, 0.18);
+    --glow-shadow: 0 18px 40px rgba(99, 102, 241, 0.35);
 }
 
-header {
-    background: linear-gradient(90deg, #6e45e2 0%, #88d3ce 100%);
-    color: white;
-    padding: 20px 40px;
-    text-align: center;
+body {
+    font-family: 'Inter', 'Segoe UI', -apple-system, BlinkMacSystemFont, sans-serif;
+    margin: 0;
+    min-height: 100vh;
+    background: var(--bg-gradient);
+    color: var(--text-primary);
+    padding: 64px 24px 96px;
+    box-sizing: border-box;
+}
+
+.app-shell {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 48px 24px 72px;
     position: relative;
 }
 
+@media (max-width: 900px) {
+    body {
+        padding: 32px 16px 64px;
+    }
+
+    .app-shell {
+        padding: 32px 16px 60px;
+    }
+
+    header {
+        padding: 32px 24px 40px;
+    }
+
+    main {
+        padding: 28px 20px 36px;
+    }
+
+    .theme-toggle {
+        top: 24px;
+        left: 24px;
+        padding: 8px 14px;
+    }
+
+    .theme-toggle span:last-child {
+        font-size: 13px;
+    }
+}
+
+@media (max-width: 640px) {
+    header {
+        padding: 28px 20px 36px;
+    }
+
+    header .author {
+        position: static;
+        margin-top: 20px;
+    }
+
+    .theme-toggle {
+        position: static;
+        margin: 0 auto 24px;
+        display: flex;
+        justify-content: center;
+    }
+
+    .tabs {
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 8px;
+    }
+
+    .tab-button {
+        flex: 1 1 45%;
+        text-align: center;
+    }
+}
+
+header {
+    background: linear-gradient(145deg, rgba(17, 24, 39, 0.8), rgba(17, 24, 39, 0.4));
+    border: 1px solid var(--shell-border);
+    border-radius: 28px;
+    padding: 48px 56px 56px;
+    text-align: center;
+    position: relative;
+    backdrop-filter: blur(18px);
+    box-shadow: var(--glow-shadow);
+}
+
 header h1 {
-    margin: 0;
-    font-weight: 500;
+    margin: 0 0 12px;
+    font-weight: 600;
+    font-size: clamp(2rem, 5vw, 3rem);
+    letter-spacing: -0.01em;
 }
 
 header p {
-    margin: 5px 0 0;
-    font-weight: 300;
+    margin: 0;
+    font-weight: 400;
+    color: var(--text-secondary);
+    line-height: 1.6;
 }
 
 header .author {
     position: absolute;
-    top: 15px;
-    right: 20px;
+    top: 28px;
+    right: 32px;
     margin: 0;
-    font-size: 12px;
-    font-weight: 400;
-    opacity: 0.8;
-    font-style: italic;
+    font-size: 13px;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-muted);
 }
 
 main {
-    padding: 20px;
+    margin-top: 36px;
+    background: var(--shell-surface);
+    border: 1px solid var(--shell-border);
+    border-radius: 28px;
+    padding: 40px 40px 48px;
+    backdrop-filter: blur(14px);
+    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.25);
 }
 
 .tabs {
     display: flex;
-    border-bottom: 1px solid #ddd;
-    margin-bottom: 20px;
+    align-items: center;
+    gap: 12px;
+    padding: 10px;
+    background: var(--tab-rail);
+    border-radius: 999px;
+    margin: 0 auto 32px;
+    width: fit-content;
+    position: relative;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12);
+    backdrop-filter: blur(16px);
 }
 
 .tab-button {
-    background: none;
+    background: transparent;
     border: none;
-    padding: 15px 20px;
+    padding: 10px 22px;
     cursor: pointer;
-    font-size: 16px;
-    font-weight: 500;
-    color: #555;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text-muted);
+    border-radius: 999px;
+    transition: all 0.25s ease;
     position: relative;
-    transition: color 0.3s;
+}
+
+.tab-button:hover {
+    color: var(--text-primary);
+}
+
+.tab-button:focus-visible {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 2px;
+    color: var(--accent-color);
 }
 
 .tab-button.active {
-    color: #6e45e2;
+    background: var(--accent-muted);
+    color: var(--accent-color);
+    box-shadow: var(--tab-shadow);
 }
 
-.tab-button.active::after {
-    content: '';
-    position: absolute;
-    bottom: -1px;
-    left: 0;
-    width: 100%;
-    height: 3px;
-    background-color: #6e45e2;
-}
-
-.content {
-    width: 100%;
-}
-
+.content,
 .content-panel {
     width: 100%;
 }
 
 .fragment-controls {
     display: flex;
-    gap: 15px;
+    gap: 16px;
     align-items: center;
-    margin-bottom: 20px;
-    padding: 10px;
-    background-color: #f9f9f9;
-    border-radius: 8px;
+    margin-bottom: 24px;
+    padding: 16px;
+    background: var(--surface-color);
+    border-radius: 18px;
+    border: 1px solid var(--surface-border);
+    box-shadow: inset 0 1px 0 var(--surface-highlight);
 }
 
 .fragment-controls input[type="text"],
 .fragment-controls select {
-    padding: 8px 12px;
-    border: 1px solid #ddd;
-    border-radius: 4px;
+    padding: 10px 14px;
+    border: 1px solid var(--surface-border);
+    border-radius: 14px;
     font-size: 14px;
+    background: rgba(15, 23, 42, 0.4);
+    color: var(--text-primary);
+    box-shadow: inset 0 1px 0 var(--surface-highlight);
+}
+
+.fragment-controls input[type="text"]::placeholder,
+.protein-controls input[type="text"]::placeholder {
+    color: var(--text-muted);
+    opacity: 0.7;
+}
+
+.fragment-controls input[type="text"]:focus,
+.fragment-controls select:focus,
+.protein-controls input[type="text"]:focus,
+.protein-controls select:focus {
+    outline: none;
+    border-color: rgba(199, 182, 255, 0.45);
+    box-shadow: 0 0 0 2px rgba(199, 182, 255, 0.18);
 }
 
 .protein-controls {
     display: flex;
-    gap: 15px;
+    gap: 16px;
     align-items: center;
-    margin-bottom: 20px;
-    padding: 10px;
-    background-color: #f9f9f9;
-    border-radius: 8px;
+    margin-bottom: 24px;
+    padding: 16px;
+    background: var(--surface-color);
+    border-radius: 18px;
+    border: 1px solid var(--surface-border);
+    box-shadow: inset 0 1px 0 var(--surface-highlight);
 }
 
 .protein-controls input[type="text"],
 .protein-controls select {
-    padding: 8px 12px;
-    border: 1px solid #ddd;
-    border-radius: 4px;
+    padding: 10px 14px;
+    border: 1px solid var(--surface-border);
+    border-radius: 14px;
     font-size: 14px;
+    background: rgba(15, 23, 42, 0.4);
+    color: var(--text-primary);
+    box-shadow: inset 0 1px 0 var(--surface-highlight);
 }
 
 .protein-controls select {
-    min-width: 200px;
+    min-width: 220px;
 }
 
 .fragment-card {
@@ -126,48 +261,53 @@ main {
 
 .fragment-info {
     font-size: 12px;
-    color: #555;
+    color: var(--text-muted);
     padding: 0 15px 10px;
 }
 
 .fragment-info p {
     margin: 4px 0;
+    color: var(--text-secondary);
 }
 
 .ccd-link {
-    color: #3a3a9e;
+    color: var(--accent-color);
     text-decoration: underline;
     cursor: pointer;
 }
 
 .ccd-link:hover {
-    color: #6e45e2;
+    color: var(--accent-strong);
 }
 
 .add-to-library-btn {
-    background-color: #4CAF50;
-    /* Green */
-    color: white;
-    border: none;
-    padding: 8px 12px;
+    background: rgba(148, 163, 184, 0.08);
+    color: var(--text-secondary);
+    border: 1px solid var(--surface-border);
+    padding: 10px 16px;
     text-align: center;
     text-decoration: none;
     display: inline-block;
-    font-size: 12px;
-    margin: 10px 15px;
+    font-size: 13px;
+    margin: 12px 15px 16px;
     cursor: pointer;
-    border-radius: 4px;
+    border-radius: 14px;
     width: calc(100% - 30px);
     box-sizing: border-box;
-    transition: background-color 0.3s;
+    transition: all 0.25s ease;
+    box-shadow: inset 0 1px 0 var(--surface-highlight), 0 10px 30px rgba(15, 23, 42, 0.2);
 }
 
 .add-to-library-btn:hover {
-    background-color: #45a049;
+    color: var(--accent-color);
+    border-color: rgba(199, 182, 255, 0.4);
+    box-shadow: var(--glow-shadow);
+    transform: translateY(-1px);
 }
 
 .add-to-library-btn.added {
-    background-color: #aaa;
+    background: rgba(148, 163, 184, 0.16);
+    color: var(--text-muted);
     cursor: not-allowed;
 }
 
@@ -203,10 +343,11 @@ main {
     text-indent: -9999px;
     width: 40px;
     height: 22px;
-    background: grey;
+    background: rgba(148, 163, 184, 0.35);
     display: block;
     border-radius: 100px;
     position: relative;
+    transition: background 0.3s ease;
 }
 
 .toggle-switch-label:after {
@@ -222,7 +363,7 @@ main {
 }
 
 .toggle-switch-checkbox:checked+.toggle-switch-label {
-    background: #6e45e2;
+    background: var(--accent-color);
 }
 
 .toggle-switch-checkbox:checked+.toggle-switch-label:after {
@@ -235,122 +376,88 @@ main {
 }
 
 
+
 .content h2 {
     margin: 0 0 20px;
-    color: #333;
-    font-weight: 500;
+    color: var(--text-primary);
+    font-weight: 600;
+    letter-spacing: -0.01em;
 }
 
 .database-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: 20px;
+    margin-bottom: 24px;
+    gap: 16px;
 }
 
 .database-header h2 {
     margin: 0;
-    color: #333;
-    font-weight: 500;
-}
-
-.add-btn {
-    background: #6e45e2;
-    color: white;
-    border: none;
-    border-radius: 50%;
-    width: 40px;
-    height: 40px;
-    font-size: 24px;
-    font-weight: 300;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: all 0.3s ease;
-    box-shadow: 0 2px 4px rgba(110, 69, 226, 0.3);
-}
-
-.add-btn:hover {
-    background: #5a37c7;
-    transform: scale(1.05);
-    box-shadow: 0 4px 8px rgba(110, 69, 226, 0.4);
+    color: var(--text-primary);
+    font-weight: 600;
 }
 
 .header-buttons {
     display: flex;
-    gap: 10px;
+    gap: 12px;
     align-items: center;
 }
 
-.delete-all-btn {
-    background: #e74c3c;
-    color: white;
-    border: none;
-    border-radius: 50%;
-    width: 40px;
-    height: 40px;
-    font-size: 18px;
-    font-weight: 300;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: all 0.3s ease;
-    box-shadow: 0 2px 4px rgba(231, 76, 60, 0.3);
-}
-
-.delete-all-btn:hover {
-    background: #c0392b;
-    transform: scale(1.05);
-    box-shadow: 0 4px 8px rgba(231, 76, 60, 0.4);
-}
-
-.delete-all-btn:active {
-    transform: scale(0.95);
-}
-
+.add-btn,
+.delete-all-btn,
 .export-btn {
-    background: #3498db;
-    color: white;
-    border: none;
-    border-radius: 50%;
-    width: 40px;
-    height: 40px;
-    font-size: 18px;
+    background: rgba(148, 163, 184, 0.08);
+    color: var(--text-secondary);
+    border: 1px solid var(--surface-border);
+    border-radius: 16px;
+    width: 44px;
+    height: 44px;
+    font-size: 20px;
+    font-weight: 500;
     cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
-    transition: all 0.3s ease;
-    box-shadow: 0 2px 4px rgba(52, 152, 219, 0.3);
+    transition: all 0.25s ease;
+    box-shadow: inset 0 1px 0 var(--surface-highlight), 0 12px 20px rgba(15, 23, 42, 0.25);
 }
 
+.add-btn:hover,
+.delete-all-btn:hover,
 .export-btn:hover {
-    background: #2980b9;
-    transform: scale(1.05);
-    box-shadow: 0 4px 8px rgba(52, 152, 219, 0.4);
+    color: var(--accent-color);
+    border-color: rgba(199, 182, 255, 0.4);
+    box-shadow: var(--glow-shadow);
+    transform: translateY(-2px);
 }
 
+.add-btn:active,
+.delete-all-btn:active,
 .export-btn:active {
-    transform: scale(0.95);
+    transform: translateY(0);
+    box-shadow: inset 0 1px 0 var(--surface-highlight);
 }
 
 .add-fragment-btn {
-    background-color: #28a745;
-    color: white;
-    border: none;
-    border-radius: 5px;
-    padding: 10px;
-    margin-top: 10px;
+    background: rgba(148, 163, 184, 0.08);
+    color: var(--text-secondary);
+    border: 1px solid var(--surface-border);
+    border-radius: 14px;
+    padding: 12px 18px;
+    margin-top: 16px;
     cursor: pointer;
     width: 100%;
-    font-weight: 500;
-    transition: background-color 0.2s;
+    font-weight: 600;
+    transition: all 0.25s ease;
+    box-shadow: inset 0 1px 0 var(--surface-highlight), 0 10px 30px rgba(15, 23, 42, 0.18);
 }
 
 .add-fragment-btn:hover {
-    background-color: #218838;
+    color: var(--accent-color);
+    border-color: rgba(199, 182, 255, 0.4);
+    box-shadow: var(--glow-shadow);
+    transform: translateY(-1px);
 }
 
 .fragment-info p {
@@ -1163,40 +1270,44 @@ main {
 .molecule-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-    gap: 20px;
+    gap: 24px;
 }
 
 .molecule-card {
-    background: white;
-    border: 1px solid #e0e0e0;
-    border-radius: 8px;
-    padding: 10px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-    transition: box-shadow 0.3s;
+    background: var(--surface-color);
+    border: 1px solid var(--surface-border);
+    border-radius: 24px;
+    padding: 24px 20px 28px;
+    box-shadow: inset 0 1px 0 var(--surface-highlight), 0 24px 60px rgba(15, 23, 42, 0.35);
+    transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
     display: flex;
     flex-direction: column;
     justify-content: space-between;
     position: relative;
+    backdrop-filter: blur(14px);
 }
 
 .drag-handle {
     position: absolute;
-    top: 8px;
+    top: 18px;
     left: 50%;
     transform: translateX(-50%);
     cursor: grab;
-    color: #ccc;
+    color: var(--text-muted);
     font-size: 16px;
-    padding: 2px 6px;
-    border-radius: 3px;
-    transition: color 0.3s;
+    padding: 4px 10px;
+    border-radius: 999px;
+    transition: all 0.3s ease;
     user-select: none;
     z-index: 10;
+    background: rgba(148, 163, 184, 0.06);
+    border: 1px solid transparent;
 }
 
 .drag-handle:hover {
-    color: #6e45e2;
-    background-color: rgba(110, 69, 226, 0.1);
+    color: var(--accent-color);
+    background: var(--accent-muted);
+    border-color: rgba(199, 182, 255, 0.4);
 }
 
 .drag-handle:active {
@@ -1205,37 +1316,32 @@ main {
 
 .delete-btn {
     position: absolute;
-    top: 8px;
-    right: 8px;
+    top: 18px;
+    right: 20px;
     cursor: pointer;
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
+    width: 32px;
+    height: 32px;
+    border-radius: 12px;
     display: flex;
     align-items: center;
     justify-content: center;
     transition: all 0.3s ease;
     user-select: none;
     z-index: 10;
-    opacity: 0.5;
-    background-color: transparent;
-    color: #757575;
+    background: rgba(148, 163, 184, 0.05);
+    color: var(--text-muted);
+    border: 1px solid transparent;
 }
 
 .delete-btn:hover {
-    opacity: 1;
-    background-color: #ffebee;
-    color: #d32f2f;
-    transform: scale(1.1);
+    color: var(--accent-color);
+    border-color: rgba(199, 182, 255, 0.4);
+    background: var(--accent-muted);
+    box-shadow: 0 12px 30px rgba(99, 102, 241, 0.25);
 }
 
 .delete-btn:active {
-    transform: scale(0.9);
-    background-color: #ffcdd2;
-}
-
-.molecule-card:hover .delete-btn {
-    opacity: 0.7;
+    transform: scale(0.95);
 }
 
 .delete-btn svg {
@@ -1244,37 +1350,32 @@ main {
 
 .download-btn {
     position: absolute;
-    top: 8px;
-    right: 40px;
+    top: 18px;
+    right: 64px;
     cursor: pointer;
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
+    width: 32px;
+    height: 32px;
+    border-radius: 12px;
     display: flex;
     align-items: center;
     justify-content: center;
     transition: all 0.3s ease;
     user-select: none;
     z-index: 10;
-    opacity: 0.5;
-    background-color: transparent;
-    color: #757575;
+    background: rgba(148, 163, 184, 0.05);
+    color: var(--text-muted);
+    border: 1px solid transparent;
 }
 
 .download-btn:hover {
-    opacity: 1;
-    background-color: #e3f2fd;
-    color: #1976d2;
-    transform: scale(1.1);
+    color: var(--accent-color);
+    border-color: rgba(199, 182, 255, 0.4);
+    background: var(--accent-muted);
+    box-shadow: 0 12px 30px rgba(99, 102, 241, 0.25);
 }
 
 .download-btn:active {
-    transform: scale(0.9);
-    background-color: #bbdefb;
-}
-
-.molecule-card:hover .download-btn {
-    opacity: 0.7;
+    transform: scale(0.95);
 }
 
 .download-btn svg {
@@ -1283,37 +1384,32 @@ main {
 
 .compare-btn {
     position: absolute;
-    top: 8px;
-    right: 72px;
+    top: 18px;
+    right: 108px;
     cursor: pointer;
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
+    width: 32px;
+    height: 32px;
+    border-radius: 12px;
     display: flex;
     align-items: center;
     justify-content: center;
     transition: all 0.3s ease;
     user-select: none;
     z-index: 10;
-    opacity: 0.5;
-    background-color: transparent;
-    color: #757575;
+    background: rgba(148, 163, 184, 0.05);
+    color: var(--text-muted);
+    border: 1px solid transparent;
 }
 
 .compare-btn:hover {
-    opacity: 1;
-    background-color: #e8f5e9;
-    color: #388e3c;
-    transform: scale(1.1);
+    color: var(--accent-color);
+    border-color: rgba(199, 182, 255, 0.4);
+    background: var(--accent-muted);
+    box-shadow: 0 12px 30px rgba(99, 102, 241, 0.25);
 }
 
 .compare-btn:active {
-    transform: scale(0.9);
-    background-color: #c8e6c9;
-}
-
-.molecule-card:hover .compare-btn {
-    opacity: 0.7;
+    transform: scale(0.95);
 }
 
 .compare-btn svg {
@@ -1323,24 +1419,26 @@ main {
 .molecule-card.dragging {
     opacity: 0.5;
     transform: rotate(5deg);
-    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+    box-shadow: var(--glow-shadow);
 }
 
 .molecule-card:hover {
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    transform: translateY(-6px);
+    border-color: rgba(199, 182, 255, 0.4);
+    box-shadow: var(--glow-shadow);
 }
 
 .molecule-card h3 {
-    margin: 0 0 5px;
-    font-size: 14px;
-    font-weight: 500;
-    color: #6e45e2;
+    margin: 12px 0 6px;
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--accent-color);
 }
 
 .molecule-card .formula {
-    margin: 0 0 10px;
-    font-size: 12px;
-    color: #888;
+    margin: 0 0 14px;
+    font-size: 13px;
+    color: var(--text-muted);
 }
 
 .molecule-card .viewer-container {
@@ -1348,8 +1446,10 @@ main {
     height: 200px;
     /* Adjust as needed */
     position: relative;
-    border: 1px solid #eee;
-    border-radius: 4px;
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    border-radius: 18px;
+    background: rgba(15, 23, 42, 0.35);
+    box-shadow: inset 0 1px 0 rgba(248, 250, 255, 0.08);
 }
 
 .fragment-card .viewer-container {
@@ -1357,31 +1457,34 @@ main {
     height: 150px;
     position: relative;
     overflow: hidden;
-    border-radius: 8px;
+    border-radius: 18px;
     display: flex;
     align-items: center;
     justify-content: center;
+    background: rgba(15, 23, 42, 0.35);
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    box-shadow: inset 0 1px 0 rgba(248, 250, 255, 0.08);
 }
 
 .fragment-card .viewer-container svg {
     max-width: 100%;
     max-height: 100%;
-    border-radius: 8px;
+    border-radius: 18px;
     display: block;
 }
 
 .molecule-card .info {
     margin-top: 10px;
     font-size: 12px;
-    color: #666;
+    color: var(--text-muted);
     display: flex;
     justify-content: space-between;
 }
 
 .molecule-card p {
-    margin: 10px 0 0;
+    margin: 16px 0 0;
     font-size: 14px;
-    color: #666;
+    color: var(--text-secondary);
 }
 
 .loading-indicator {
@@ -1389,7 +1492,7 @@ main {
     text-align: center;
     padding: 40px;
     font-size: 18px;
-    color: #888;
+    color: var(--text-muted);
 }
 
 .pdb-details-modal {
@@ -1726,75 +1829,61 @@ main {
 /* Theme toggle button */
 .theme-toggle {
     position: absolute;
-    top: 15px;
-    left: 20px;
-    background: transparent;
-    border: none;
-    color: white;
+    top: 28px;
+    left: 32px;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 16px;
+    border-radius: 999px;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    background: rgba(148, 163, 184, 0.08);
+    color: var(--text-secondary);
     cursor: pointer;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    transition: all 0.25s ease;
+    box-shadow: inset 0 1px 0 var(--surface-highlight), 0 12px 24px rgba(15, 23, 42, 0.25);
+}
+
+.theme-toggle:hover {
+    color: var(--accent-color);
+    border-color: rgba(199, 182, 255, 0.4);
+    box-shadow: var(--glow-shadow);
+    transform: translateY(-2px);
+}
+
+.theme-toggle:active {
+    transform: translateY(0);
 }
 
 .theme-toggle .material-icons {
-    font-size: 24px;
+    font-size: 20px;
 }
 
 /* Dark mode styles */
 body.dark-mode {
-    background-color: #121212;
-    color: #eee;
-}
-
-body.dark-mode header {
-    background: linear-gradient(90deg, #333 0%, #555 100%);
-}
-
-body.dark-mode .theme-toggle {
-    color: #ffd54f;
-}
-
-body.dark-mode .tabs {
-    border-bottom-color: #444;
-}
-
-body.dark-mode .tab-button {
-    color: #bbb;
-}
-
-body.dark-mode .tab-button.active {
-    color: #fff;
-}
-
-body.dark-mode .tab-button.active::after {
-    background-color: #fff;
-}
-
-body.dark-mode .fragment-controls,
-body.dark-mode .protein-controls {
-    background-color: #2c2c2c;
-}
-
-body.dark-mode .database-header h2 {
-    color: #eee;
-}
-
-body.dark-mode .molecule-card {
-    background: #151515;
-    border-color: #333;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
-}
-
-body.dark-mode .molecule-card h3 {
-    color: #88d3ce;
-}
-
-body.dark-mode .molecule-card .formula,
-body.dark-mode .molecule-card .info,
-body.dark-mode .molecule-card p {
-    color: #ccc;
+    --bg-gradient: radial-gradient(circle at 15% -10%, rgba(148, 163, 255, 0.18), transparent 55%),
+        radial-gradient(circle at 90% 0%, rgba(129, 140, 248, 0.15), transparent 50%),
+        #04060f;
+    --shell-surface: rgba(4, 9, 24, 0.8);
+    --shell-border: rgba(99, 102, 241, 0.35);
+    --surface-color: rgba(7, 12, 28, 0.78);
+    --surface-border: rgba(99, 102, 241, 0.25);
+    --surface-highlight: rgba(255, 255, 255, 0.08);
+    --accent-color: #d8ccff;
+    --accent-strong: #efe5ff;
+    --accent-muted: rgba(192, 181, 255, 0.22);
+    --text-primary: #f5f7ff;
+    --text-secondary: rgba(220, 228, 255, 0.85);
+    --text-muted: rgba(199, 210, 254, 0.7);
+    --tab-rail: rgba(99, 102, 241, 0.2);
+    --tab-shadow: 0 18px 40px rgba(99, 102, 241, 0.35);
+    --glow-shadow: 0 24px 60px rgba(79, 70, 229, 0.45);
 }
 
 body.dark-mode .viewer-container,
 body.dark-mode .molecule-viewer,
 body.dark-mode .details-viewer {
-    background: #e0e0e0;
+    background: rgba(241, 245, 255, 0.9);
 }


### PR DESCRIPTION
## Summary
- adopt an Inter-based app shell with a Claude-inspired theme toggle and hero layout
- restyle tabs, forms, and action buttons using glassy surfaces and new design tokens for light/dark palettes
- refresh molecule and fragment cards plus inline SMILES placeholders to match the updated palette

## Testing
- Not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_690495faad308329a85f99329531e4ea